### PR TITLE
Removal of Koinos Types in documentation

### DIFF
--- a/docs/quickstart/developer-guide.md
+++ b/docs/quickstart/developer-guide.md
@@ -29,14 +29,6 @@ $ brew install cmake clang
 $ sudo apt install build-essentials libgmp cmake
 ```
 
-#### Python
-
-Currently, [Koinos Types](https://github.com/koinos/koinos-types) requires the installation of Python3 as well as some additional python packages. Ensure that Python3 is installed and install the necessary python packages.
-
-```console
-$ pip3 install --user dataclasses_json Jinja2 importlib_resources pluginbase gitpython
-```
-
 ### Building projects
 
 For this example we will use the [Koinos Chain](https://github.com/koinos/koinos-chain) microservice. Let's begin by cloning the repository.

--- a/docs/tutorials/custom-types-contract.md
+++ b/docs/tutorials/custom-types-contract.md
@@ -4,7 +4,7 @@ This tutorial aims to demonstrate how to create smart contracts using custom typ
 
 ## Setting up the project
 
-C++ smart contracts are built using either Docker or the CMake build system. For this tutorial, we will use CMake. We will assume you have already set up your CDT. If you have not, the [Contract developer guide](../quickstart/contract_developer-guide.md) documents this process. Let us begin by setting up our directory structure.
+C++ smart contracts are built using either Docker or the CMake build system. For this tutorial, we will use CMake. We will assume you have already set up your CDT. If you have not, the [Contract developer guide](../quickstart/contract-developer-guide.md) documents this process. Let us begin by setting up our directory structure.
 
 ```console
 $ cp -R cmake_project calculator_contract


### PR DESCRIPTION
* Removes reference to `Koinos Types` as it is no longer used
* Fixes an incorrect link