### PR TITLE
fix: Link to the sample contracts 

### DIFF
--- a/docs/quickstart/contract-developer-guide.md
+++ b/docs/quickstart/contract-developer-guide.md
@@ -125,7 +125,7 @@ $ cmake -DCMAKE_TOOLCHAIN_FILE=${KOINOS_CDT_ROOT}/cmake/koinos-wasm-toolchain.cm
 $ make -j
 ```
 
-There is a skeleton cmake project in [Koinos Contract Examples](https://github.com/koinos/koinos-contract-examples/cmake_project) that you can use for your own smart contracts.
+There is a skeleton cmake project in [Koinos Contract Examples](https://github.com/koinos/koinos-contract-examples) that you can use for your own smart contracts.
 
 After building your smart contract you will find two important artifacts in your build directory.
 - The WASM binary (`*.wasm`)


### PR DESCRIPTION
The link to the sample contracts was going nowhere. This now points to the repo directly.

<img width="1680" alt="Screen Shot 2021-11-16 at 20 04 31" src="https://user-images.githubusercontent.com/60598000/142040766-d419ec0f-0bed-43d1-9db4-3b113aedc0c2.png">


