### PR TITLE
fix: Link to the sample contract calculator ABI file

### DIFF
--- a/docs/tutorials/custom-types-contract.md
+++ b/docs/tutorials/custom-types-contract.md
@@ -207,7 +207,7 @@ This will create two build artifacts, `build/src/contract.wasm` and `build/types
 
 We will use the [Koinos Command Line Interface (CLI)](https://github.com/koinos/koinos-cli) to interact with this contract on the blockchain. We need the Application Binary Interface (ABI) to inform the CLI how to invoke methods on the contract. For more information about the ABI file please refer to the [Contract ABI](../architecture/contract-abi.md) section.
 
-The contract examples repo already contains the [ABI file](https://github.com/koinos/koinos-contract-examples/contracts/calculator/calc.abi). The ABI File contains JSON information about each of the entry points as well as the base64 encoded protobuf descriptor file (`types.pb`) that was generated during compilation. Encoding the base64 descriptor file can be done with a simple command.
+The contract examples repo already contains the [ABI file](https://github.com/koinos/koinos-contract-examples/blob/master/contracts/calculator/calc.abi). The ABI File contains JSON information about each of the entry points as well as the base64 encoded protobuf descriptor file (`types.pb`) that was generated during compilation. Encoding the base64 descriptor file can be done with a simple command.
 
 ```console
 $ cat types/types.pb | base64


### PR DESCRIPTION
The link to the sample contract calculator ABI file was going nowhere. This now points to the master.

<img width="1325" alt="Screen Shot 2021-11-16 at 20 03 38" src="https://user-images.githubusercontent.com/60598000/142040657-43bac4fa-7937-4f5b-9927-34a76142b22b.png">

