### PR TITLE
Add KCS-1 standard information and links to the token guide

### DIFF
--- a/docs/developers/guides/token.md
+++ b/docs/developers/guides/token.md
@@ -1,7 +1,10 @@
 # Token
-Welcome to our guide on launching a token collection using the Koinos Contract Standard (KCS-1) for tokens and the AssemblyScript SDK for Koinos. In this tutorial, we'll walk you through the process of creating and deploying your own token on the Koinos blockchain. Whether you're a seasoned developer or new to blockchain development, this step-by-step guide will provide you with the knowledge and tools necessary to bring your token project to life. Let's dive in and explore the exciting world of token creation on Koinos!
+Welcome to our guide on launching a token collection using the Koinos Contract Standard ([KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md)) for tokens and the AssemblyScript SDK for Koinos. In this tutorial, we'll walk you through the process of creating and deploying your own token on the Koinos blockchain. Whether you're a seasoned developer or new to blockchain development, this step-by-step guide will provide you with the knowledge and tools necessary to bring your token project to life. Let's dive in and explore the exciting world of token creation on Koinos!
 
 Before starting, ensure that you have already set up your Koinos AssemblyScript SDK environment by following [this guide](../as-sdk.md).
+
+!!! note
+    The [KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) token may not be compatible with certain dApps such as KoinDX. You should understand the requirements of your token before adhering to any particular standard. Visit the [Koinos Contract Standards repository](https://github.com/koinos/koinos-contract-standards) for more information.
 
 ---
 ## Setting up the project

--- a/docs/developers/guides/token.md
+++ b/docs/developers/guides/token.md
@@ -4,7 +4,7 @@ Welcome to our guide on launching a token collection using the Koinos Contract S
 Before starting, ensure that you have already set up your Koinos AssemblyScript SDK environment by following [this guide](../as-sdk.md).
 
 !!! note
-    The [KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) token may not be compatible with certain dApps such as KoinDX. You should understand the requirements of your token before adhering to any particular standard. Visit the [Koinos Contract Standards repository](https://github.com/koinos/koinos-contract-standards) for more information.
+    The [KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) token may not be compatible with certain dApps such as [KoinDX](https://koindx.com). You should understand the requirements of your token before adhering to any particular standard. Visit the [Koinos Contract Standards repository](https://github.com/koinos/koinos-contract-standards) for more information.
 
 ---
 ## Setting up the project

--- a/docs/developers/guides/token.md
+++ b/docs/developers/guides/token.md
@@ -6,6 +6,8 @@ Before starting, ensure that you have already set up your Koinos AssemblyScript 
 !!! note
     The [KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) token may not be compatible with certain dApps such as [KoinDX](https://koindx.com). You should understand the requirements of your token before adhering to any particular standard. Visit the [Koinos Contract Standards repository](https://github.com/koinos/koinos-contract-standards) for more information.
 
+    The [KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) standard is insecure. The security is improved by [KCS-3](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-3.md) and [KCS-4](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-4.md). A more detailed description of the vulnerability can be found [here](https://peakd.com/koinos/@jga/improve-security-koinos).
+
 ---
 ## Setting up the project
 Let's begin by creating a boilerplate smart contract project using the Koinos AssemblyScript SDK.


### PR DESCRIPTION
Resolves #206.

## Brief description
Adds links to the relevant standards. Adds a note about the consequences of choosing a particular standard and links to the KCS repository.

Blocked by koinos/koinos-contract-standards#8.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
![image](https://github.com/koinos/koinos-docs/assets/778036/fbb063b9-bba2-4f88-a215-a7cbd848e516)
