### PR TITLE
feat: redesign documentation structure with 9-section approach

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,54 +8,75 @@ The Koinos blockchain is purposefully designed with developers in mind, offering
 
 <div class="grid cards" markdown>
 
--   :fontawesome-solid-mountain-sun:{ .lg .middle } __Overview__
+-   :fontawesome-solid-play:{ .lg .middle } __Getting Started__
 
     ---
 
-    Gain insight into the innovative features and unique capabilities that make Koinos a powerful platform for decentralized applications and smart contracts.
+    Quick overview to get your first KOIN balance, create accounts, and perform essential tasks to start using the Koinos blockchain.
 
-    [:octicons-arrow-right-24: Getting started](overview/index.md)
+    [:octicons-arrow-right-24: Get started](getting-started/index.md)
 
--   :fontawesome-solid-laptop-code:{ .lg .middle } __Developers__
-
-    ---
-
-    Explore the developer section of the Koinos documentation to delve into comprehensive resources and tools tailored for building on the Koinos blockchain.
-
-    [:octicons-arrow-right-24: Start building](developers/index.md)
-
--   :fontawesome-solid-check:{ .lg .middle } __Validators__
+-   :fontawesome-solid-plug:{ .lg .middle } __Interacting with Koinos__
 
     ---
 
-    Learn how to participate in block production, secure the network, and earn rewards by becoming a validator in the Koinos ecosystem.
-    <br/><br/>
+    Learn how to interact with the Koinos blockchain using Koilib, REST APIs, and web development tools to build applications and integrations.
 
-    [:octicons-arrow-right-24: Power the network](validators/index.md)
+    [:octicons-arrow-right-24: Start interacting](interacting/index.md)
 
--   :fontawesome-solid-right-left:{ .lg .middle } __Exchanges__
+-   :fontawesome-solid-code:{ .lg .middle } __Smart Contract Development__
 
     ---
 
-    Explore best practices, technical specifications, and tools necessary to support KOIN trading and liquidity within the broader cryptocurrency market.
-    <br/><br/>
+    Comprehensive guide to developing smart contracts on Koinos using AssemblyScript SDK, contract deployment, and testing frameworks.
 
-    [:octicons-arrow-right-24: Let's integrate](exchanges/index.md)
+    [:octicons-arrow-right-24: Start building](contracts/index.md)
+
+-   :fontawesome-solid-server:{ .lg .middle } __Node Operators__
+
+    ---
+
+    Everything you need to know about running Koinos nodes, from RPC nodes to block producers, including setup, configuration, and maintenance.
+
+    [:octicons-arrow-right-24: Run a node](nodes/index.md)
 
 -   :fontawesome-solid-sitemap:{ .lg .middle } __Architecture__
 
     ---
 
-    Explore the innovative features, consensus mechanism, scalability solutions, and technical details that make Koinos a robust and developer-friendly blockchain platform.
-    <br/><br/>
+    Deep technical dive into Koinos architecture, microservices, consensus mechanisms, and the innovative features that power the blockchain.
 
     [:octicons-arrow-right-24: How it works](architecture/index.md)
 
--   :fontawesome-solid-list:{ .lg .middle } __Resources__
+-   :fontawesome-solid-cogs:{ .lg .middle } __System Contracts__
 
     ---
 
-    The resources section is your comprehensive hub for accessing essential tools, libraries, and community resources to accelerate your development journey on the Koinos blockchain. 
+    Understand the core system contracts that govern tokenomics, governance, resource management, and other fundamental blockchain operations.
 
-    [:octicons-arrow-right-24: Browse resources](resources/index.md)
+    [:octicons-arrow-right-24: System internals](system-contracts/index.md)
+
+-   :fontawesome-solid-vote-yea:{ .lg .middle } __Governance Proposals__
+
+    ---
+
+    Learn how to participate in Koinos governance by submitting proposals, voting on changes, and contributing to the network's evolution.
+
+    [:octicons-arrow-right-24: Participate](governance/index.md)
+
+-   :fontawesome-solid-book:{ .lg .middle } __References__
+
+    ---
+
+    Complete API references for Koilib, AssemblyScript SDK, and other development tools with detailed documentation and examples.
+
+    [:octicons-arrow-right-24: Browse references](references/index.md)
+
+-   :fontawesome-solid-link:{ .lg .middle } __Resources__
+
+    ---
+
+    External links, explorers, wallets, libraries, and community resources to accelerate your development journey on Koinos.
+
+    [:octicons-arrow-right-24: Explore tools](resources/index.md)
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,8 @@ theme:
     # - navigation.instant
     # - navigation.prune
     - navigation.sections
-    # - navigation.tabs
-    # - navigation.tabs.sticky
+    - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
     - navigation.tracking
     - search.highlight
@@ -125,57 +125,50 @@ nav:
     - getting-started/accounts-keys-wallets.md
     - getting-started/mainnet-vs-testnet.md
     - getting-started/tooling-overview.md
-  # - Overview:
-  #   - overview/index.md
-  #   - overview/blockchain-basics.md
-  #   - overview/governance.md
-  #   - overview/mana.md
-  #   - overview/proof-of-burn.md
-  #   - overview/smart-contracts.md
-  #   - overview/tokenomics.md
-  - Interacting with Koinos:
-    - interacting/index.md
-    - interacting/quick-start.md
-    - interacting/read-contract-data.md
-    - interacting/submit-transaction.md
-    - interacting/multiple-operations.md
-    - interacting/testnet.md
-    - interacting/rest-api.md
-    - interacting/kondor-wallet.md
-    - Common Tasks:
-      - exchanges/index.md
-      - exchanges/head-block.md
-      - exchanges/create-wallet.md
-      - exchanges/account-balance.md
-      - exchanges/transfer.md
-      - exchanges/mana.md
-      - exchanges/offline-signing.md
-      - exchanges/multisig.md
-      - exchanges/finality.md
-      - exchanges/account-history.md
-      - exchanges/cli.md
-      - exchanges/jsonrpc.md
-      - exchanges/koilib.md
-      - exchanges/rest.md
-    - Tutorials:
-      - interacting/tutorials/frontend-guide.md
-  - Smart Contract Development:
-    - contracts/index.md
-    - contracts/quick-start.md
-    - contracts/storage.md
-    - contracts/external-functions.md
-    - contracts/protobuffers.md
-    - contracts/call-other-contracts.md
-    - contracts/check-authorization.md
-    - contracts/authorize-function.md
-    - contracts/verify-signatures.md
-    - contracts/system-events.md
-    - contracts/logs.md
-    - contracts/build-testnet.md
-    - contracts/deploy-contract.md
-    - contracts/examples.md
-    - Tutorials:
-      - contracts/tutorials/contract-guide.md
+  - Building:
+    - Interacting with Koinos:
+      - interacting/index.md
+      - interacting/quick-start.md
+      - interacting/read-contract-data.md
+      - interacting/submit-transaction.md
+      - interacting/multiple-operations.md
+      - interacting/testnet.md
+      - interacting/rest-api.md
+      - interacting/kondor-wallet.md
+      - Common Tasks:
+        - exchanges/index.md
+        - exchanges/head-block.md
+        - exchanges/create-wallet.md
+        - exchanges/account-balance.md
+        - exchanges/transfer.md
+        - exchanges/mana.md
+        - exchanges/offline-signing.md
+        - exchanges/multisig.md
+        - exchanges/finality.md
+        - exchanges/account-history.md
+        - exchanges/cli.md
+        - exchanges/jsonrpc.md
+        - exchanges/koilib.md
+        - exchanges/rest.md
+      - Tutorials:
+        - interacting/tutorials/frontend-guide.md
+    - Smart Contract Development:
+      - contracts/index.md
+      - contracts/quick-start.md
+      - contracts/storage.md
+      - contracts/external-functions.md
+      - contracts/protobuffers.md
+      - contracts/call-other-contracts.md
+      - contracts/check-authorization.md
+      - contracts/authorize-function.md
+      - contracts/verify-signatures.md
+      - contracts/system-events.md
+      - contracts/logs.md
+      - contracts/build-testnet.md
+      - contracts/deploy-contract.md
+      - contracts/examples.md
+      - Tutorials:
+        - contracts/tutorials/contract-guide.md
   # - Developers:
   #   - developers/index.md
   #   - developers/as-sdk.md
@@ -214,62 +207,64 @@ nav:
   #   - Guides:
   #     - validators/guides/block-production.md
   #     - validators/guides/running-a-node.md
-  - Architecture:
-    - architecture/index.md
-    - Microservices:
-      - architecture/microservices/koinos-chain.md
-      - architecture/microservices/block-store.md
-      - architecture/microservices/p2p.md
-      - architecture/microservices/mempool.md
-      - architecture/microservices/transaction-store.md
-      - architecture/microservices/block-producer.md
-      - architecture/microservices/json-rpc.md
-      - architecture/microservices/grpc.md
-      - architecture/microservices/contract-meta-store.md
-      - architecture/microservices/account-history.md
-    - architecture/interprocess-communication.md
-    - architecture/serialization.md
-    - architecture/smart-contracts.md
-    - architecture/contract-abi.md
-    - architecture/resources.md
-    - architecture/system-calls.md
-    - architecture/proof-of-burn.md
-  - System Contracts:
-    - system-contracts/index.md
-    - system-contracts/tokenomics.md
-    - system-contracts/koin-vhp.md
-    - system-contracts/proof-of-burn.md
-    - system-contracts/mana.md
-    - system-contracts/governance.md
-    - system-contracts/name-service.md
-    - system-contracts/resources.md
-    - system-contracts/koinos-fund.md
-  - Governance Proposals:
-    - governance/index.md
-    - governance/submit-proposal.md
-    - History of Updates:
-      - governance/history/vhp-bug.md
-      - governance/history/system-contract-metadata.md
-      - governance/history/allowances.md
-      - governance/history/koinos-fund.md
-  - References:
-    - references/index.md
-    - Koilib Reference:
-      - references/koilib/contract-class.md
-      - references/koilib/provider-class.md
-      - references/koilib/serializer-class.md
-      - references/koilib/signer-class.md
-      - references/koilib/transaction-class.md
-      - references/koilib/util-functions.md
-    - Assembly Script SDK Reference:
-      - references/as-sdk/system-class.md
-      - references/as-sdk/storage-classes.md
-      - references/as-sdk/encoding-functions.md
-      - references/as-sdk/koinosbox-functions.md
+  - Technical:
+    - Architecture:
+      - architecture/index.md
+      - Microservices:
+        - architecture/microservices/koinos-chain.md
+        - architecture/microservices/block-store.md
+        - architecture/microservices/p2p.md
+        - architecture/microservices/mempool.md
+        - architecture/microservices/transaction-store.md
+        - architecture/microservices/block-producer.md
+        - architecture/microservices/json-rpc.md
+        - architecture/microservices/grpc.md
+        - architecture/microservices/contract-meta-store.md
+        - architecture/microservices/account-history.md
+      - architecture/interprocess-communication.md
+      - architecture/serialization.md
+      - architecture/smart-contracts.md
+      - architecture/contract-abi.md
+      - architecture/resources.md
+      - architecture/system-calls.md
+      - architecture/proof-of-burn.md
+    - System Contracts:
+      - system-contracts/index.md
+      - system-contracts/tokenomics.md
+      - system-contracts/koin-vhp.md
+      - system-contracts/proof-of-burn.md
+      - system-contracts/mana.md
+      - system-contracts/governance.md
+      - system-contracts/name-service.md
+      - system-contracts/resources.md
+      - system-contracts/koinos-fund.md
+    - Governance Proposals:
+      - governance/index.md
+      - governance/submit-proposal.md
+      - History of Updates:
+        - governance/history/vhp-bug.md
+        - governance/history/system-contract-metadata.md
+        - governance/history/allowances.md
+        - governance/history/koinos-fund.md
   - Resources:
-    - resources/index.md
-    - resources/wallets.md
-    - resources/explorers.md
-    - resources/ecosystem-platforms.md
-    - resources/contract-standards.md
-    - resources/software-libraries.md
+    - References:
+      - references/index.md
+      - Koilib Reference:
+        - references/koilib/contract-class.md
+        - references/koilib/provider-class.md
+        - references/koilib/serializer-class.md
+        - references/koilib/signer-class.md
+        - references/koilib/transaction-class.md
+        - references/koilib/util-functions.md
+      - Assembly Script SDK Reference:
+        - references/as-sdk/system-class.md
+        - references/as-sdk/storage-classes.md
+        - references/as-sdk/encoding-functions.md
+        - references/as-sdk/koinosbox-functions.md
+    - External Resources:
+      - resources/index.md
+      - resources/wallets.md
+      - resources/explorers.md
+      - resources/ecosystem-platforms.md
+      - resources/contract-standards.md
+      - resources/software-libraries.md


### PR DESCRIPTION
## 📚 Documentation Structure Redesign

### Summary
Redesigns the documentation structure with a new 9-section approach focused on user tasks and improved navigation UX.

### Changes Made
- ✅ **New homepage layout**: 9 task-focused cards replacing the old 6-section approach  
- ✅ **Reorganized navigation**: Consolidated into 5 manageable top-level tabs
- ✅ **Improved UX**: Sticky navigation tabs with lateral subsection menus
- ✅ **Logical grouping**: Related content grouped under broader categories

### New Structure
1. **Getting Started** - Quick tasks (KOIN balance, accounts, etc.)
2. **Building** - Interacting + Smart Contract Development  
3. **Node Operators** - RPC nodes, block producers, configuration
4. **Technical** - Architecture + System Contracts + Governance
5. **Resources** - References + External Resources

### Preview
The changes can be previewed by checking out this branch and running:
```bash
source docs-venv/bin/activate && mkdocs serve
```

### Breaking Changes
None - all existing content preserved, only reorganized for better discoverability.