### PR TITLE
Clarify REST API documentation

### DIFF
--- a/docs/contracts/quick-start.md
+++ b/docs/contracts/quick-start.md
@@ -6,7 +6,7 @@ Create and deploy your first token contract using the Arkinos framework.
 
 - Node.js 16+ installed
 - Basic TypeScript/AssemblyScript knowledge
-- Testnet KOIN for deployment (get from [faucet](https://faucet.koinos.io))
+- Testnet KOIN for deployment (get from the [Telegram faucet bot](https://t.me/KoinosTestnetFaucetBot))
 
 ## Installation
 
@@ -106,7 +106,7 @@ arkinos generate
 module.exports = {
   networks: {
     harbinger: {
-      rpcUrl: "https://harbinger-api.koinos.io",
+      rpcUrl: "https://testnet.koinosfoundation.org",
       accounts: {
         manaSharer: {
           privateKey: "YOUR_PRIVATE_KEY" // Use environment variable
@@ -130,7 +130,7 @@ After deployment, you'll get a contract address. Test it:
 const { Provider, Contract } = require('koilib');
 const abi = require('./abi/mytoken-abi.json');
 
-const provider = new Provider('https://harbinger-api.koinos.io');
+const provider = new Provider('https://testnet.koinosfoundation.org');
 const contract = new Contract({
   id: 'YOUR_CONTRACT_ADDRESS',
   provider,

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -55,7 +55,7 @@ This comprehensive resource hub is designed to empower developers to leverage th
     ---
 
     
-    Introducing the Harbinger testnet for the Koinos blockchain, a dedicated environment where developers can experiment with Koinos features, test smart contracts, and simulate real-world scenarios before deploying on the mainnet. The Harbinger testnet provides a safe and sandboxed environment for developers to validate their applications and gain insights into the capabilities and performance of the Koinos blockchain platform.
+    Introducing the Koinos Foundation testnet, a dedicated environment where developers can experiment with Koinos features, test smart contracts, and simulate real-world scenarios before deploying on the mainnet. The public testnet provides a safe and sandboxed environment for developers to validate their applications and gain insights into the capabilities and performance of the Koinos blockchain platform.
 
     [:octicons-arrow-right-24: Let's prototype](testnet.md)
 

--- a/docs/developers/rest.md
+++ b/docs/developers/rest.md
@@ -5,7 +5,20 @@ hide:
 ---
 
 # REST API
-The REST API provided by Koinos offers developers a convenient and straightforward way to interact with the blockchain using standard HTTP methods. This API simplifies integration and development by abstracting complex blockchain interactions into intuitive HTTP endpoints, making it accessible to a wider audience of developers who are familiar with web technologies. With the REST API, developers can easily query blockchain data, submit transactions, and interact with smart contracts without the need for specialized blockchain knowledge, streamlining the development process for decentralized applications (dApps) on the Koinos platform.
+The REST API provided by Koinos offers developers a convenient and straightforward way to interact with the blockchain using standard HTTP methods. This API simplifies integration and development by exposing intuitive HTTP endpoints for querying blockchain data, preparing transactions, submitting signed transactions, and interacting with smart contracts.
+
+Public endpoints are available at:
+
+- Mainnet: [`https://api.koinos.io`](https://api.koinos.io)
+- Testnet: [`https://harbinger-api.koinos.io`](https://harbinger-api.koinos.io)
+
+For example, the current head block information can be queried with:
+
+```bash
+curl https://api.koinos.io/v1/chain/head_info
+```
+
+Transaction endpoints are available under `/v1/transaction`, including `/v1/transaction/prepare` and `/v1/transaction/submit`. The REST API can help prepare and submit transactions, but applications are still responsible for safely managing accounts and signatures. If a transaction is already built and signed, it can be submitted over HTTP. If an application needs to create and sign transactions itself, it should use a Koinos-compatible signing library or service before calling the submit endpoint.
 
 ---
 <swagger-ui src="./swagger.json">

--- a/docs/developers/rest.md
+++ b/docs/developers/rest.md
@@ -10,7 +10,7 @@ The REST API provided by Koinos offers developers a convenient and straightforwa
 Public endpoints are available at:
 
 - Mainnet: [`https://api.koinos.io`](https://api.koinos.io)
-- Testnet: [`https://harbinger-api.koinos.io`](https://harbinger-api.koinos.io)
+- Testnet: [`https://testnet.koinosfoundation.org`](https://testnet.koinosfoundation.org)
 
 For example, the current head block information can be queried with:
 

--- a/docs/developers/swagger.json
+++ b/docs/developers/swagger.json
@@ -10,8 +10,8 @@
       "description": "Koinos Mainnet"
     },
     {
-      "url": "https://harbinger-api.koinos.io",
-      "description": "Koinos Harbinger Testnet"
+      "url": "https://testnet.koinosfoundation.org",
+      "description": "Koinos Foundation Testnet"
     }
   ],
   "components": {
@@ -2135,4 +2135,3 @@
     }
   }
 }
-

--- a/docs/developers/testnet.md
+++ b/docs/developers/testnet.md
@@ -6,66 +6,48 @@ icon: fontawesome/solid/network-wired
 A blockchain testnet serves as a sandbox environment for developers and users to experiment, test, and deploy smart contracts, decentralized applications (DApps), and other blockchain-related functionalities without using real cryptocurrency or affecting the main blockchain network. Testnets mimic the behavior of the main blockchain but operate with fake or test tokens, allowing users to simulate real-world scenarios and interactions in a risk-free environment. They provide a platform for developers to debug code, identify potential vulnerabilities, and gauge the performance and scalability of their applications before deploying them on the mainnet. Testnets also facilitate collaboration among developers and enable the community to contribute to the improvement and evolution of blockchain protocols and applications through feedback and testing.
 
 ---
-## Harbinger
-While anyone has the ability to spin up a testnet, Koinos Group provides a testnet for general use called Harbinger. To target a particular testnet one must retrieve the chain ID. The chain ID prevents your transaction from being valid on any other blockchain other than the one you are targeting.
+## Koinos Foundation testnet
+While anyone has the ability to spin up a testnet, the Koinos Foundation maintains a public testnet endpoint for general development use. To target a particular testnet one must retrieve the chain ID. The chain ID prevents your transaction from being valid on any other blockchain other than the one you are targeting.
 
-It is important to retrieve a fresh chain ID from Harbinger when doing work on testnet as it is not uncommon for the testnet to be restarted with a new chain ID. In other words, do not just copy this chain ID, retrieve it yourself before you use it.
+It is important to retrieve a fresh chain ID when doing work on testnet as it is not uncommon for a testnet to be restarted with a new chain ID. In other words, do not just copy this chain ID, retrieve it yourself before you use it.
 
 !!! example
     An example of retrieving the Chain ID through JSON-RPC.
     ```sh
-    curl -d '{"jsonrpc":"2.0", "id":0, "method":"chain.get_chain_id", "params":{}}' 'https://api.harbinger.koinos.pro/jsonrpc?apikey=<APIKEY>'
+    curl -d '{"jsonrpc":"2.0", "id":0, "method":"chain.get_chain_id", "params":{}}' 'https://testnet.koinosfoundation.org/jsonrpc'
     ```
     ```json
     {
       "jsonrpc": "2.0",
       "result": {
-        "chain_id": "EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ=="
+        "chain_id": "EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ=="
       },
       "id": 0
     }
     ```
 
-Using the chain ID retrieved and your preferred Harbinger endpoint, you can use the testnet to deploy contracts and test your dApp. As you know, every action on Koinos requires Mana so we will need to acquire KOIN for testing. On testnet we call it tKOIN.
+Using the chain ID retrieved and your preferred testnet endpoint, you can use the testnet to deploy contracts and test your dApp. As you know, every action on Koinos requires Mana so we will need to acquire KOIN for testing. On testnet we call it tKOIN.
 
 ---
 ## tKOIN and the faucet
 tKOIN is the Koinos blockchain testnet token symbol.
 
-Once you have your public address you can join our [Discord](https://discord.koinos.io) server and request some tKOIN in the `#faucet` channel under the Developer section by sending the following message to the faucet bot:
+Once you have your public address you can request tKOIN from the [Koinos Testnet Faucet bot](https://t.me/KoinosTestnetFaucetBot) on Telegram:
 
 ### Example of acquiring tKOIN
 The command to receive tKOIN from the faucet is as follows:
 ```
-!faucet <public address>
+/faucet <public address>
 ```
 
 !!! example
-    Given that your public address is `1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe`, within the `#faucet` channel write the following text command.
+    Given that your public address is `1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe`, send the following text command to the Telegram faucet bot.
     ```sh
-    !faucet 1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe
+    /faucet 1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe
     ```
 
 !!! success
-    Upon success, you were see the following response from the Harbinger Faucet.
+    Upon success, the faucet transfers test KOIN to your address.
     ```{ .txt, .no-copy }
     Transferring 100.000000 tKOIN to address 1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe.
-    ```
-
-### Example of checking your tKOIN balance
-The command to check your balance from the faucet is as follows:
-```
-!balance <public address>
-```
-
-!!! example
-    Given that your public address is `1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe`, within the `#faucet` channel write the following text command.
-    ```sh
-    !balance 1ENxxuH81kytBdYe81fD9BdYe81fD9Qxe
-    ```
-
-!!! success
-    Upon success, you were see the following response from the Harbinger Faucet.
-    ```{ .txt, .no-copy }
-    Balance at address 1ENxxuH81kytBdYe81fD9tBdYe81fD9Qxe is 100.000000 tKOIN.
     ```

--- a/docs/exchanges/multisig.md
+++ b/docs/exchanges/multisig.md
@@ -67,8 +67,8 @@ Below you can find examples of how to perform multisig using a variety of suppor
     Base64:
     CiISIBi1R__zgY16nsHh5_Fb4c5vcZ2RNmLbdK8S14n8Xrh6EocBCiISIGdwPikpEhBZyj9ZGqjlD7GddHsm47c-1m_3zeYp0odJEIDC1y8aAigBIiISIKOpklf8aTYyWEznjTSfcsxYAeij5YlyGD5rew7hxKHvKhkAld7Gt6Kcrgx74cp4Bu_njyA2IGaZDR5YMhkAYdZB07coryO66Iuhp1Eu5_fj30VjGeuYGmESXwoZAJ_lH9WcjJMQmBCDCX0CXh1NdTgPLp-Z_BDK7dW_Aho8ChkAYdZB07coryO66Iuhp1Eu5_fj30VjGeuYEhkAld7Gt6Kcrgx74cp4Bu_njyA2IGaZDR5YGICU69wDIkEfyNwas3pxwjEYVubcI6En9e91L1fl-R7q-Gj4Y5fVfZE074Nqf0ZUbkJkcYfAuuVnJi604i-yOG90Jm2hHlYgiw==
 
-    🚫 🔓 > connect https://api.harbinger.koinos.pro/jsonrpc?apikey=APIKEY
-    Connected to endpoint https://api.harbinger.koinos.pro/jsonrpc?apikey=APIKEY
+    🚫 🔓 > connect https://testnet.koinosfoundation.org/jsonrpc
+    Connected to endpoint https://testnet.koinosfoundation.org/jsonrpc
 
     🔓 > open wallets/test.wallet password
     Opened wallet: wallets/test.wallet

--- a/docs/exchanges/offline-signing.md
+++ b/docs/exchanges/offline-signing.md
@@ -9,7 +9,7 @@ The Chain ID is a unique identifier for the specific chain you are transacting o
 | Blockchain        | Chain ID                                           |
 |-------------------|----------------------------------------------------|
 | Koinos Mainnet    | `EiBZK_GGVP0H_fXVAM3j6EAuz3-B-l3ejxRSewi7qIBfSA==` |
-| Harbinger Testnet | `EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ==` |
+| Koinos Foundation Testnet | `EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ==` |
 
 ---
 ## Nonce

--- a/docs/exchanges/rest.md
+++ b/docs/exchanges/rest.md
@@ -10,7 +10,7 @@ You can view the [REST documentation](../developers/rest.md) to learn more.
 The public REST API is available at:
 
 - Mainnet: [`https://api.koinos.io`](https://api.koinos.io)
-- Testnet: [`https://harbinger-api.koinos.io`](https://harbinger-api.koinos.io)
+- Testnet: [`https://testnet.koinosfoundation.org`](https://testnet.koinosfoundation.org)
 
 The same API is also available on [Koinos**Pro**](https://koinos.pro). You can sign up for a free account and begin working with the REST API immediately.
 

--- a/docs/exchanges/rest.md
+++ b/docs/exchanges/rest.md
@@ -7,6 +7,11 @@ The Koinos REST API provides a clean and simple way of interacting with the Koin
 
 You can view the [REST documentation](../developers/rest.md) to learn more.
 
-The REST API is available on [Koinos**Pro**](https://koinos.pro). You can sign up for a free account and begin working with the REST API immediately. 
+The public REST API is available at:
+
+- Mainnet: [`https://api.koinos.io`](https://api.koinos.io)
+- Testnet: [`https://harbinger-api.koinos.io`](https://harbinger-api.koinos.io)
+
+The same API is also available on [Koinos**Pro**](https://koinos.pro). You can sign up for a free account and begin working with the REST API immediately.
 
 You can also access the REST API by running your own Koinos node. Learn how to run a Koinos node [here](../validators/guides/running-a-node.md). To enable the REST API, you will need to have `rest`, `api`, or `all` set in your `COMPOSE_PROFILES`. 

--- a/docs/getting-started/mainnet-vs-testnet.md
+++ b/docs/getting-started/mainnet-vs-testnet.md
@@ -9,7 +9,7 @@ Understanding the different Koinos networks and how to connect to them.
 - **KOIN**: Real cryptocurrency with market value
 - **Use for**: Live applications and real transactions
 
-### Testnet (Harbinger)
+### Testnet
 - **Purpose**: Testing and development
 - **KOIN**: Test tokens with no real value
 - **Use for**: Development, testing, and experimentation
@@ -27,25 +27,24 @@ const provider = new Provider('https://api.koinos.io');
 ```javascript
 import { Provider } from 'koilib';
 
-const provider = new Provider('https://harbinger-api.koinos.io');
+const provider = new Provider('https://testnet.koinosfoundation.org');
 ```
 
 ### Network Configuration
 
 | Setting | Mainnet | Testnet |
 |---------|---------|---------|
-| Chain ID | `EiBZK_GGVP0H_fXVAM3j6EAuz3-B-l3ejxRSewi7qIBfSA` | `EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ` |
-| API Endpoint | `https://api.koinos.io` | `https://harbinger-api.koinos.io` |
-| RPC Endpoint | `https://api.koinos.io` | `https://harbinger-api.koinos.io` |
+| Chain ID | `EiBZK_GGVP0H_fXVAM3j6EAuz3-B-l3ejxRSewi7qIBfSA` | `EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ==` |
+| API Endpoint | `https://api.koinos.io` | `https://testnet.koinosfoundation.org` |
+| RPC Endpoint | `https://api.koinos.io/jsonrpc` | `https://testnet.koinosfoundation.org/jsonrpc` |
 
 ## Getting Test Tokens
 
 For testnet development, you can get free test KOIN from the faucet:
 
-1. Visit the [Koinos Testnet Faucet](https://faucet.koinos.io)
-2. Enter your testnet address
-3. Complete the captcha
-4. Receive test KOIN
+1. Open the [Koinos Testnet Faucet bot](https://t.me/KoinosTestnetFaucetBot) on Telegram.
+2. Send `/faucet YOUR_KOINOS_ADDRESS`.
+3. Receive test KOIN for development and testing.
 
 ## Best Practices
 

--- a/docs/getting-started/tooling-overview.md
+++ b/docs/getting-started/tooling-overview.md
@@ -98,7 +98,7 @@ Command-line interface for blockchain interaction
 
 ### Development Networks
 - **Local testnet**: For private development
-- **Harbinger testnet**: Public testing network
+- **Koinos Foundation testnet**: Public testing network
 
 ## Choosing the Right Tool
 

--- a/docs/interacting/kondor-wallet.md
+++ b/docs/interacting/kondor-wallet.md
@@ -153,7 +153,7 @@ window.kondor.on('networkChanged', (network) => {
     updateProvider('https://api.koinos.io');
   } else if (network === 'testnet') {
     // Switch to testnet endpoints
-    updateProvider('https://harbinger-api.koinos.io');
+    updateProvider('https://testnet.koinosfoundation.org');
   }
 });
 ```
@@ -232,7 +232,7 @@ class KondorIntegration {
     console.log('Network changed:', network);
     const endpoint = network === 'mainnet' 
       ? 'https://api.koinos.io' 
-      : 'https://harbinger-api.koinos.io';
+      : 'https://testnet.koinosfoundation.org';
     
     this.provider = new Provider(endpoint);
     if (this.signer) {

--- a/docs/interacting/rest-api.md
+++ b/docs/interacting/rest-api.md
@@ -10,7 +10,7 @@ The Koinos REST API provides HTTP endpoints for querying blockchain data, prepar
 
 ```text
 Mainnet: https://api.koinos.io
-Testnet: https://harbinger-api.koinos.io
+Testnet: https://testnet.koinosfoundation.org
 ```
 
 The live Swagger documentation is available at:

--- a/docs/interacting/rest-api.md
+++ b/docs/interacting/rest-api.md
@@ -1,16 +1,22 @@
 # REST API
 
-Learn how to interact with Koinos using the REST API for HTTP-based blockchain access.
+Learn how to interact with Koinos using standard HTTP requests.
 
 ## Overview
 
-The Koinos REST API provides HTTP endpoints for blockchain interaction, making it easy to integrate with web applications and services that prefer REST over JSON-RPC.
+The Koinos REST API provides HTTP endpoints for querying blockchain data, preparing transactions, submitting signed transactions, and interacting with smart contracts. It is useful for web applications, services, exchanges, and backends that prefer REST over direct JSON-RPC calls.
 
 ## Base URL
 
-```
+```text
 Mainnet: https://api.koinos.io
 Testnet: https://harbinger-api.koinos.io
+```
+
+The live Swagger documentation is available at:
+
+```text
+https://api.koinos.io/swagger
 ```
 
 ## Common Endpoints
@@ -18,70 +24,57 @@ Testnet: https://harbinger-api.koinos.io
 ### Chain Information
 
 ```bash
-# Get head block info
-GET /v1/chain/head_info
-
-# Get block by height
-GET /v1/chain/get_block?height=12345
-
-# Get block by ID
-GET /v1/chain/get_block?id=0x1220...
+# Get current head block information
+curl https://api.koinos.io/v1/chain/head_info
 ```
 
-### Account Information
+### Transactions
+
+The REST API can help prepare and submit transactions, but applications are still responsible for safely managing accounts and signatures.
 
 ```bash
-# Get account balance
-GET /v1/chain/get_account_nonce?account=1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe
-
-# Get account RC (mana)
-GET /v1/chain/get_account_rc?account=1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe
+# Prepare a transaction
+curl -X POST https://api.koinos.io/v1/transaction/prepare \
+  -H "Content-Type: application/json" \
+  -d '{
+    "header": {
+      "rc_limit": "200000000",
+      "payer": "17CmTGbriMyCypF6WdTRJGhzur3SoJXAG5"
+    },
+    "operations": []
+  }'
 ```
 
-### Contract Calls
+If the transaction is already built and signed, it can be submitted over HTTP to `/v1/transaction/submit`. If an application needs to create and sign Koinos transactions itself, it should use a Koinos-compatible signing library or service before calling the submit endpoint.
+
+### JSON-RPC Access
+
+For lower-level access, the public API also exposes JSON-RPC:
 
 ```bash
-# Read contract (GET)
-POST /v1/chain/read_contract
-Content-Type: application/json
-
-{
-  "contract_id": "19GYjDBVXU7keLbYvMLazsGQn3GTWHjHkK",
-  "entry_point": 0x82a3537ff,
-  "args": "base64-encoded-args"
-}
+curl -X POST https://api.koinos.io/jsonrpc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "chain.get_head_info",
+    "params": {},
+    "id": 1
+  }'
 ```
 
 ## Example Usage
 
-### JavaScript/Node.js
+### JavaScript / Node.js
 
 ```javascript
-const axios = require('axios');
-
-const API_BASE = 'https://api.koinos.io';
+const API_BASE = "https://api.koinos.io";
 
 async function getHeadInfo() {
-  try {
-    const response = await axios.get(`${API_BASE}/v1/chain/head_info`);
-    console.log('Head block:', response.data);
-  } catch (error) {
-    console.error('API Error:', error.response.data);
+  const response = await fetch(`${API_BASE}/v1/chain/head_info`);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
   }
-}
-
-async function getAccountBalance(address) {
-  try {
-    const response = await axios.post(`${API_BASE}/v1/chain/read_contract`, {
-      contract_id: '19GYjDBVXU7keLbYvMLazsGQn3GTWHjHkK',
-      entry_point: 0x82a3537ff, // balanceOf function
-      args: btoa(address) // base64 encode address
-    });
-    
-    console.log('Balance:', response.data);
-  } catch (error) {
-    console.error('Balance query failed:', error);
-  }
+  return response.json();
 }
 ```
 
@@ -89,87 +82,37 @@ async function getAccountBalance(address) {
 
 ```python
 import requests
-import base64
 
-API_BASE = 'https://api.koinos.io'
+API_BASE = "https://api.koinos.io"
 
 def get_head_info():
-    response = requests.get(f'{API_BASE}/v1/chain/head_info')
-    return response.json()
-
-def get_account_rc(account):
-    response = requests.get(
-        f'{API_BASE}/v1/chain/get_account_rc',
-        params={'account': account}
-    )
+    response = requests.get(f"{API_BASE}/v1/chain/head_info")
+    response.raise_for_status()
     return response.json()
 ```
 
-### cURL
-
-```bash
-# Get head block
-curl -X GET "https://api.koinos.io/v1/chain/head_info"
-
-# Get account RC
-curl -X GET "https://api.koinos.io/v1/chain/get_account_rc?account=1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe"
-
-# Read contract
-curl -X POST "https://api.koinos.io/v1/chain/read_contract" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "contract_id": "19GYjDBVXU7keLbYvMLazsGQn3GTWHjHkK",
-    "entry_point": 2186741247,
-    "args": "base64-encoded-arguments"
-  }'
-```
+PHP backends can call the same HTTP endpoints with their preferred HTTP client. They can submit signed transactions with normal HTTP requests, but building and signing transactions requires Koinos-compatible transaction serialization and signing before submission.
 
 ## Error Handling
 
-```javascript
-async function handleAPICall() {
-  try {
-    const response = await axios.get(`${API_BASE}/v1/chain/head_info`);
-    return response.data;
-  } catch (error) {
-    if (error.response) {
-      // Server responded with error status
-      console.error('API Error:', error.response.status, error.response.data);
-    } else if (error.request) {
-      // Request was made but no response
-      console.error('Network Error:', error.message);
-    } else {
-      // Something else happened
-      console.error('Error:', error.message);
-    }
-    throw error;
-  }
-}
-```
+REST endpoints return JSON responses for validation and execution errors. For example, submitting an empty transaction body to `/v1/transaction/submit` returns a validation error because the endpoint expects a prepared transaction object.
 
-## Rate Limiting
+Applications should:
 
-Most public endpoints have rate limits:
-- Respect rate limit headers in responses
-- Implement exponential backoff for retries
-- Consider caching responses when appropriate
+1. Check HTTP status codes.
+2. Parse JSON error bodies.
+3. Retry transient network errors with backoff.
+4. Use testnet for development before submitting transactions on mainnet.
 
 ## Best Practices
 
-1. **Use appropriate HTTP methods** (GET for reads, POST for writes)
-2. **Handle errors gracefully** with proper error codes
-3. **Implement retries** with exponential backoff
-4. **Cache responses** when data doesn't change frequently
-5. **Use testnet** for development and testing
-
-## Limitations
-
-- REST API may not support all JSON-RPC methods
-- Some operations may require JSON-RPC for full functionality
-- Transaction submission typically requires JSON-RPC
+1. Use `GET` for read endpoints and `POST` for transaction, contract, and decode endpoints.
+2. Keep private keys out of public clients and logs.
+3. Sign transactions with a Koinos-compatible wallet, SDK, or signing service.
+4. Use the Swagger documentation to confirm request and response shapes.
+5. Cache responses when data does not need to be live.
 
 ## Next Steps
 
 - [Work with Kondor wallet](kondor-wallet.md)
 - [Explore testnet](testnet.md)
-

--- a/docs/interacting/testnet.md
+++ b/docs/interacting/testnet.md
@@ -1,10 +1,10 @@
 # Testnet Development
 
-Learn how to use the Koinos testnet (Harbinger) for development and testing.
+Learn how to use the Koinos testnet for development and testing.
 
 ## Overview
 
-The Koinos testnet, called "Harbinger," is a testing environment that mirrors mainnet functionality but uses test tokens with no real value. It's perfect for development, testing, and experimentation.
+The Koinos testnet is a testing environment that mirrors mainnet functionality but uses test tokens with no real value. It's perfect for development, testing, and experimentation.
 
 ## Network Configuration
 
@@ -12,11 +12,11 @@ The Koinos testnet, called "Harbinger," is a testing environment that mirrors ma
 
 | Setting | Value |
 |---------|-------|
-| Network Name | Harbinger (Testnet) |
-| Chain ID | `EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ` |
-| API Endpoint | `https://harbinger-api.koinos.io` |
-| RPC Endpoint | `https://harbinger-api.koinos.io` |
-| Explorer | [Harbinger Explorer](https://harbinger.koinosblocks.com) |
+| Network Name | Koinos Foundation testnet |
+| Chain ID | `EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ==` |
+| API Endpoint | `https://testnet.koinosfoundation.org` |
+| RPC Endpoint | `https://testnet.koinosfoundation.org/jsonrpc` |
+| Health | `https://testnet.koinosfoundation.org/health` |
 
 ### Connecting to Testnet
 
@@ -26,14 +26,14 @@ The Koinos testnet, called "Harbinger," is a testing environment that mirrors ma
 const { Provider } = require('koilib');
 
 // Connect to testnet
-const provider = new Provider('https://harbinger-api.koinos.io');
+const provider = new Provider('https://testnet.koinosfoundation.org');
 ```
 
 #### Using Kondor Wallet
 
 1. Open Kondor wallet
 2. Click on network selector (usually shows "Mainnet")
-3. Select "Harbinger" or "Testnet"
+3. Select the testnet network
 4. Confirm network switch
 
 ## Getting Test Tokens
@@ -42,29 +42,9 @@ const provider = new Provider('https://harbinger-api.koinos.io');
 
 Get free test KOIN from the faucet:
 
-1. **Visit the faucet**: [https://faucet.koinos.io](https://faucet.koinos.io)
-2. **Enter your testnet address**
-3. **Complete the captcha**
-4. **Receive test KOIN** (usually 100 KOIN)
-
-### Using the Faucet Programmatically
-
-```javascript
-const axios = require('axios');
-
-async function requestTestTokens(address) {
-  try {
-    const response = await axios.post('https://faucet.koinos.io/api/faucet', {
-      address: address,
-      captcha_token: 'your-captcha-token' // If required
-    });
-    
-    console.log('Faucet response:', response.data);
-  } catch (error) {
-    console.error('Faucet request failed:', error);
-  }
-}
-```
+1. **Open the faucet bot**: [https://t.me/KoinosTestnetFaucetBot](https://t.me/KoinosTestnetFaucetBot)
+2. **Send** `/faucet YOUR_KOINOS_ADDRESS`
+3. **Receive test KOIN** for development and testing
 
 ## Development Setup
 
@@ -75,9 +55,9 @@ const { Provider, Signer, Contract, utils } = require('koilib');
 
 // Testnet configuration
 const TESTNET_CONFIG = {
-  endpoint: 'https://harbinger-api.koinos.io',
-  chainId: 'EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ',
-  koinContract: '19GYjDBVXU7keLbYvMLazsGQn3GTWHjHkK'
+  endpoint: 'https://testnet.koinosfoundation.org',
+  chainId: 'EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ==',
+  koinContract: '1FaSvLjQJsCJKq5ybmGsMMQs8RQYyVv8ju'
 };
 
 async function setupTestnet() {
@@ -107,8 +87,8 @@ async function setupTestnet() {
 const config = {
   development: {
     network: 'testnet',
-    endpoint: 'https://harbinger-api.koinos.io',
-    chainId: 'EiBncD4pKRIQWco_WRqo5Q-xnXR7JuO3PtZv983mKdKHSQ'
+    endpoint: 'https://testnet.koinosfoundation.org',
+    chainId: 'EiAIKVvm6-V2qmsmUvPJy09vCCLbtn9lHFpwrJbcTIEWRQ=='
   },
   production: {
     network: 'mainnet',
@@ -134,7 +114,7 @@ describe('Contract Tests', () => {
   
   beforeAll(async () => {
     // Use testnet for all tests
-    provider = new Provider('https://harbinger-api.koinos.io');
+    provider = new Provider('https://testnet.koinosfoundation.org');
     signer = Signer.fromPrivateKey(process.env.TEST_PRIVATE_KEY);
     signer.provider = provider;
     
@@ -168,8 +148,8 @@ describe('Contract Tests', () => {
 // test/integration.test.js
 describe('Integration Tests', () => {
   test('complete user flow', async () => {
-    // 1. Get test tokens from faucet
-    await requestTestTokens(testAddress);
+    // 1. Get test tokens from the faucet bot
+    // https://t.me/KoinosTestnetFaucetBot
     
     // 2. Deploy test contract
     const contract = await deployTestContract();
@@ -189,7 +169,7 @@ describe('Integration Tests', () => {
 
 ```javascript
 async function deployToTestnet() {
-  const provider = new Provider('https://harbinger-api.koinos.io');
+  const provider = new Provider('https://testnet.koinosfoundation.org');
   const signer = Signer.fromPrivateKey(process.env.TESTNET_PRIVATE_KEY);
   signer.provider = provider;
   
@@ -216,7 +196,7 @@ async function deployToTestnet() {
 
 ```javascript
 async function debugTransaction(txId) {
-  const provider = new Provider('https://harbinger-api.koinos.io');
+  const provider = new Provider('https://testnet.koinosfoundation.org');
   
   try {
     const transaction = await provider.getTransaction(txId);
@@ -236,8 +216,7 @@ async function debugTransaction(txId) {
 
 ### Monitoring Tools
 
-- **[Harbinger Explorer](https://harbinger.koinosblocks.com)**: View transactions and blocks
-- **[Koiner Testnet](https://harbinger.koiner.app)**: Advanced blockchain explorer
+- **Public health endpoint**: [https://testnet.koinosfoundation.org/health](https://testnet.koinosfoundation.org/health)
 - **Logs**: Monitor contract logs and events
 
 ## Best Practices
@@ -253,7 +232,7 @@ async function debugTransaction(txId) {
 ## Common Issues
 
 **Insufficient test tokens**: Use the faucet to get more KOIN
-**Network mismatch**: Ensure you're connected to Harbinger testnet
+**Network mismatch**: Ensure you're connected to the Koinos Foundation testnet
 **Contract not found**: Verify contract address on testnet
 **Transaction failures**: Check testnet block explorer for details
 
@@ -271,4 +250,3 @@ async function debugTransaction(txId) {
 
 - [Learn about common tasks](../exchanges/head-block.md)
 - [Explore frontend tutorials](tutorials/frontend-guide.md)
-

--- a/docs/interacting/tutorials/frontend-guide.md
+++ b/docs/interacting/tutorials/frontend-guide.md
@@ -498,7 +498,7 @@ class KoinosApp {
         if (network === 'mainnet') {
             this.wallet.provider = new Provider('https://api.koinos.io');
         } else if (network === 'testnet') {
-            this.wallet.provider = new Provider('https://harbinger-api.koinos.io');
+            this.wallet.provider = new Provider('https://testnet.koinosfoundation.org');
         }
     }
     


### PR DESCRIPTION
## Summary
- add public REST API mainnet/testnet endpoints to developer and exchange docs
- clarify that transaction submission expects prepared/signed transactions
- refresh the REST interaction guide with verified cURL, JSON-RPC, Node fetch, and Python examples
- update public testnet references to https://testnet.koinosfoundation.org and the Telegram faucet bot

## Testing
- curl https://api.koinos.io/v1/chain/head_info
- curl POST https://api.koinos.io/v1/transaction/prepare
- curl POST https://api.koinos.io/jsonrpc with chain.get_head_info
- curl https://testnet.koinosfoundation.org/health
- curl POST https://testnet.koinosfoundation.org/jsonrpc with chain.get_chain_id
- curl https://testnet.koinosfoundation.org/v1/chain/head_info
- Node.js fetch example
- Python requests example
- docs-venv/bin/mkdocs build

Note: mkdocs build succeeds. Existing documentation warnings remain for unrelated missing nav/link targets.