### PR TITLE
docs: fix Getting Started example links

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -49,8 +49,8 @@ does not create a wallet, request a private key, or submit a transaction.
 --8<-- "examples/javascript/getting-started/read-koin-balance/index.js:program"
 ```
 
-[View complete file](https://github.com/koinos/koinos-docs/blob/master/examples/javascript/getting-started/read-koin-balance/index.js) ·
-[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/read-koin-balance?startScript=start)
+[View complete file](https://github.com/koinos/koinos-docs/blob/dev/examples/javascript/getting-started/read-koin-balance/index.js) ·
+[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/read-koin-balance?startScript=start)
 
 The hosted example uses a public address by default. When running the complete
 file locally, you can pass any valid **public address**:

--- a/docs/getting-started/mainnet-vs-testnet.md
+++ b/docs/getting-started/mainnet-vs-testnet.md
@@ -33,8 +33,8 @@ and print the live chain ID and head height.
 --8<-- "examples/javascript/getting-started/network-provider/index.js:mainnet"
 ```
 
-[View complete file](https://github.com/koinos/koinos-docs/blob/master/examples/javascript/getting-started/network-provider/index.js) ·
-[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/network-provider?startScript=start)
+[View complete file](https://github.com/koinos/koinos-docs/blob/dev/examples/javascript/getting-started/network-provider/index.js) ·
+[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/network-provider?startScript=start)
 
 ### Public testnet
 
@@ -43,8 +43,8 @@ and print the live chain ID and head height.
 --8<-- "examples/javascript/getting-started/network-provider/index.js:testnet"
 ```
 
-[View complete file](https://github.com/koinos/koinos-docs/blob/master/examples/javascript/getting-started/network-provider/index.js) ·
-[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/network-provider?startScript=testnet)
+[View complete file](https://github.com/koinos/koinos-docs/blob/dev/examples/javascript/getting-started/network-provider/index.js) ·
+[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/network-provider?startScript=testnet)
 
 Koilib sends JSON-RPC requests directly to the URL supplied to `Provider`.
 The testnet root, `https://testnet.koinosfoundation.org/`, is retained as a

--- a/docs/getting-started/tooling-overview.md
+++ b/docs/getting-started/tooling-overview.md
@@ -30,8 +30,8 @@ The following setup creates a mainnet provider and a disposable local signer:
 --8<-- "examples/javascript/references/koilib-api-tour/index.js:tooling"
 ```
 
-[View complete file](https://github.com/koinos/koinos-docs/blob/master/examples/javascript/references/koilib-api-tour/index.js) ·
-[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/references/koilib-api-tour)
+[View complete file](https://github.com/koinos/koinos-docs/blob/dev/examples/javascript/references/koilib-api-tour/index.js) ·
+[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/references/koilib-api-tour)
 
 The complete Node.js example reads live data and exercises additional Koilib
 APIs, but it does not broadcast a transaction. Its signer uses a deliberately
@@ -60,8 +60,8 @@ This feature check lets a dApp display an appropriate unavailable-wallet state:
 --8<-- "examples/javascript/browser/kondor-dapp/src/wallet.js:detect"
 ```
 
-[View complete file](https://github.com/koinos/koinos-docs/blob/master/examples/javascript/browser/kondor-dapp/src/wallet.js) ·
-[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/browser/kondor-dapp)
+[View complete file](https://github.com/koinos/koinos-docs/blob/dev/examples/javascript/browser/kondor-dapp/src/wallet.js) ·
+[Run example](https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/browser/kondor-dapp)
 
 The hosted runner shows the unavailable-wallet state when Kondor is not
 installed in that browser. Account and signature requests always require user

--- a/examples/javascript/manifest.json
+++ b/examples/javascript/manifest.json
@@ -17,10 +17,11 @@
       "safety": "read-only",
       "project": "examples/javascript/getting-started/read-koin-balance",
       "source": "examples/javascript/getting-started/read-koin-balance/index.js",
+      "sourceRef": "dev",
       "snippet": "program",
       "runner": {
         "type": "stackblitz",
-        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/read-koin-balance?startScript=start"
+        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/read-koin-balance?startScript=start"
       }
     },
     {
@@ -37,10 +38,11 @@
       "safety": "read-only",
       "project": "examples/javascript/getting-started/network-provider",
       "source": "examples/javascript/getting-started/network-provider/index.js",
+      "sourceRef": "dev",
       "snippet": "mainnet",
       "runner": {
         "type": "stackblitz",
-        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/network-provider?startScript=start"
+        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/network-provider?startScript=start"
       }
     },
     {
@@ -57,10 +59,11 @@
       "safety": "read-only",
       "project": "examples/javascript/getting-started/network-provider",
       "source": "examples/javascript/getting-started/network-provider/index.js",
+      "sourceRef": "dev",
       "snippet": "testnet",
       "runner": {
         "type": "stackblitz",
-        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/getting-started/network-provider?startScript=testnet"
+        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/getting-started/network-provider?startScript=testnet"
       }
     },
     {
@@ -77,10 +80,11 @@
       "safety": "local-only",
       "project": "examples/javascript/references/koilib-api-tour",
       "source": "examples/javascript/references/koilib-api-tour/index.js",
+      "sourceRef": "dev",
       "snippet": "tooling",
       "runner": {
         "type": "stackblitz",
-        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/references/koilib-api-tour"
+        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/references/koilib-api-tour"
       }
     },
     {
@@ -756,10 +760,11 @@
       "safety": "read-only",
       "project": "examples/javascript/browser/kondor-dapp",
       "source": "examples/javascript/browser/kondor-dapp/src/wallet.js",
+      "sourceRef": "dev",
       "snippet": "detect",
       "runner": {
         "type": "stackblitz",
-        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/master/examples/javascript/browser/kondor-dapp"
+        "url": "https://stackblitz.com/fork/github/koinos/koinos-docs/tree/dev/examples/javascript/browser/kondor-dapp"
       }
     },
     {

--- a/scripts/verify-javascript-examples.mjs
+++ b/scripts/verify-javascript-examples.mjs
@@ -108,9 +108,10 @@ for (const docPath of walk(path.join(root, "docs"))) {
     }
 
     const links = findLinks(lines, closingFenceIndex);
+    const sourceRef = entry.sourceRef ?? manifest.publishedBranch;
     const expectedSourceUrl =
       `https://github.com/koinos/koinos-docs/blob/` +
-      `${manifest.publishedBranch}/${entry.source}`;
+      `${sourceRef}/${entry.source}`;
     if (links.source !== expectedSourceUrl) {
       errors.push(
         `${doc}:${line}: ${id} source link must be ${expectedSourceUrl}`


### PR DESCRIPTION
## Summary

- point the five Getting Started source links at files that exist on `dev`
- point the five Getting Started StackBlitz runners at projects on `dev`
- allow individual manifest entries to override the default published source ref
- keep every non-Getting Started example on its existing source ref

## Why

The Getting Started pages were merged into `dev`, but their example links still
targeted `master`. Because those files do not exist on `master` yet, source links
returned 404 and runners could not be accepted from the rendered development
documentation.

## Verification

- `npm run examples:verify`
- `npm run examples:syntax`
- `npm run examples:test`
- `npm run docs:links`
- `docs-venv/bin/mkdocs build`
- all affected GitHub and StackBlitz URLs return HTTP 200
- browser click-through from Mainnet vs Testnet opens the source on `dev`
- browser click-through imports the StackBlitz project and successfully runs
  the mainnet example, printing its chain ID and head height
