### PR TITLE
Update Resources documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,13 +76,22 @@ Koinos is a next-generation blockchain platform designed to be **truly accessibl
 
     [:octicons-arrow-right-24: Integrate trading](exchanges/index.md)
 
--   :fontawesome-solid-book:{ .lg .middle } __References & Resources__
+-   :fontawesome-solid-book:{ .lg .middle } __References__
 
     ---
 
-    API references, troubleshooting guides, community links, and additional resources to support your Koinos development journey.
+    Look up API, SDK, contract, and troubleshooting reference material.
 
-    [:octicons-arrow-right-24: Browse resources](references/index.md)
+    [:octicons-arrow-right-24: Open references](references/index.md)
+
+-   :fontawesome-solid-compass:{ .lg .middle } __Resources__
+
+    ---
+
+    Find verified wallets, explorers, ecosystem applications, developer tools,
+    contract standards, and community links.
+
+    [:octicons-arrow-right-24: Browse resources](resources/index.md)
 
 </div>
 

--- a/docs/resources/community-and-learning.md
+++ b/docs/resources/community-and-learning.md
@@ -1,0 +1,79 @@
+# Community and learning
+
+Use these links to ask questions, follow project updates, learn from examples,
+and contribute corrections. Public chat and third-party content can be wrong or
+outdated; verify technical advice against current versioned documentation and
+source code.
+
+## Official project sources
+
+- [Koinos website](https://koinos.io/) — project information and official
+  links.
+- [Koinos documentation](https://docs.koinos.io/) — published guides and
+  references.
+- [Koinos GitHub organization](https://github.com/koinos) — source repositories,
+  releases, and issue trackers.
+- [Koinos Docs repository](https://github.com/koinos/koinos-docs) —
+  documentation source and contribution history.
+
+## Discussion channels
+
+- [Koinos Telegram](https://telegram.koinos.io/) — public community discussion.
+- [Koinos Discord](https://discord.koinos.io/) — community and developer
+  discussion.
+- [Koinos on X](https://x.com/koinosnetwork) — project announcements and links.
+
+No moderator or contributor should ask for a recovery phrase, WIF, or private
+key. Do not treat a direct message as proof of identity. Reproduce technical
+advice on a test account or test network before applying it to valuable assets
+or production infrastructure.
+
+## Articles, videos, and learning paths
+
+- [Koinos YouTube](https://www.youtube.com/@koinosgroup) contains project
+  presentations and tutorials.
+- [Koinos Network on Medium](https://medium.com/koinosnetwork) contains project
+  articles and announcements.
+- [Getting Started](../getting-started/index.md) is the recommended path for new
+  users.
+- [Interacting with Koinos](../interacting/index.md) covers wallet, API, and
+  transaction workflows.
+- [Smart Contracts](../contracts/index.md) covers contract development.
+- [Node Operators](../nodes/index.md) covers running node infrastructure.
+- [Architecture](../architecture/index.md) explains protocol and service
+  design.
+
+Older articles and videos may reference obsolete releases or networks. Check
+the publication date and compare commands, endpoints, and package versions with
+the current canonical repository before using them.
+
+## Contribute or report stale documentation
+
+For a small correction, open a pull request against
+[koinos/koinos-docs](https://github.com/koinos/koinos-docs). For a broken link,
+obsolete instruction, or uncertain technical claim, open a
+[documentation issue](https://github.com/koinos/koinos-docs/issues/new) with:
+
+- the affected page URL and section;
+- the statement or link that appears stale;
+- the current canonical source, tag, or commit;
+- the date and network on which you verified the problem.
+
+Check a repository's `CONTRIBUTING.md` and target branch before opening a pull
+request.
+
+## Propose a Resources entry
+
+Open a documentation issue or pull request with enough evidence to verify the
+entry:
+
+1. Category and concise factual purpose.
+2. Maintainer and whether it is official, community-maintained, or third-party.
+3. Canonical site and source repository, when source is public.
+4. Supported Koinos network or networks.
+5. Current release, package, tag, or immutable commit for technical claims.
+6. Verification date and known limitations.
+
+An ecosystem directory or project name can be used for discovery, but it is not
+enough evidence by itself. Entries that cannot be independently verified may be
+left out until current canonical evidence is available.

--- a/docs/resources/contract-standards.md
+++ b/docs/resources/contract-standards.md
@@ -1,53 +1,60 @@
-# Contract Standards
+# Contract standards
 
-Standard interfaces and patterns for Koinos smart contracts.
+Koinos Contract Standards (KCSs) describe interfaces intended to improve
+interoperability between contracts and applications. They are separate from
+governance proposals.
 
-## Overview
+The titles and statuses below were checked on **2026-07-25** against commit
+[`ef6f3d8`](https://github.com/koinos/koinos-contract-standards/commit/ef6f3d8edc75673842e927edba1232fe47df51e4)
+of the canonical
+[koinos/koinos-contract-standards](https://github.com/koinos/koinos-contract-standards)
+repository.
 
-Contract standards ensure interoperability between different applications and provide consistent interfaces for common functionality.
+## Published standards
 
-## Token Standards
+### KCS-1 — Token Standard
 
-### KCS-1: Fungible Tokens
-- **Purpose**: Standard interface for fungible tokens
-- **Functions**: transfer, balanceOf, totalSupply, approve, allowance
-- **Usage**: Most tokens follow this standard for compatibility
+- **Status:** Final.
+- **Purpose:** defines a base interface for tokens on Koinos.
+- **Sources:** [reviewed commit](https://github.com/koinos/koinos-contract-standards/blob/ef6f3d8edc75673842e927edba1232fe47df51e4/KCSs/kcs-1.md)
+  and [latest KCS-1](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md).
 
-### KCS-2: Non-Fungible Tokens (NFTs)
-- **Purpose**: Standard interface for unique digital assets
-- **Functions**: ownerOf, transferFrom, approve, tokenURI
-- **Usage**: NFT collections and marketplaces
+### KCS-2 — NFT Collection Standard
 
-## DeFi Standards
+- **Status:** Final.
+- **Purpose:** defines a base interface for NFT collections.
+- **Sources:** [reviewed commit](https://github.com/koinos/koinos-contract-standards/blob/ef6f3d8edc75673842e927edba1232fe47df51e4/KCSs/kcs-2.md)
+  and [latest KCS-2](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-2.md).
 
-### KCS-3: Decentralized Exchange
-- **Purpose**: Standard interface for DEX contracts
-- **Functions**: addLiquidity, removeLiquidity, swap
-- **Usage**: Trading platforms and aggregators
+### KCS-3 — Token Standard that mimics ERC-20
 
-### KCS-4: Staking Contracts
-- **Purpose**: Standard interface for staking mechanisms
-- **Functions**: stake, unstake, claimRewards, getStakeInfo
-- **Usage**: Yield farming and staking platforms
+- **Status:** Final.
+- **Purpose:** defines an ERC-20-like token interface for Koinos.
+- **Sources:** [reviewed commit](https://github.com/koinos/koinos-contract-standards/blob/ef6f3d8edc75673842e927edba1232fe47df51e4/KCSs/kcs-3.md)
+  and [latest KCS-3](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-3.md).
 
-## Governance Standards
+### KCS-4 — Token Standard that mimics ERC-20 and supports Koinos authority system
 
-### KCS-5: Governance Tokens
-- **Purpose**: Standard interface for governance participation
-- **Functions**: propose, vote, execute, getVotingPower
-- **Usage**: DAO and governance systems
+- **Status:** Pending.
+- **Purpose:** extends an ERC-20-like token interface with the Koinos authority
+  system.
+- **Sources:** [reviewed commit](https://github.com/koinos/koinos-contract-standards/blob/ef6f3d8edc75673842e927edba1232fe47df51e4/KCSs/kcs-4.md)
+  and [latest KCS-4](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-4.md).
 
-## Best Practices
+### KCS-5 — NFT Standard that mimics ERC-721 and supports Koinos authority system
 
-1. **Follow established standards** for interoperability
-2. **Implement proper interfaces** for contract interactions
-3. **Use consistent naming** conventions
-4. **Provide comprehensive documentation**
-5. **Test compatibility** with existing tools
+- **Status:** Pending.
+- **Purpose:** defines an ERC-721-like NFT interface with the Koinos authority
+  system.
+- **Sources:** [reviewed commit](https://github.com/koinos/koinos-contract-standards/blob/ef6f3d8edc75673842e927edba1232fe47df51e4/KCSs/kcs-5.md)
+  and [latest KCS-5](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-5.md).
 
-## Next Steps
+Use the immutable links above when reviewing the version summarized here. Check
+the [latest KCS directory](https://github.com/koinos/koinos-contract-standards/tree/master/KCSs)
+before implementing a standard because titles, statuses, and specifications can
+change.
 
-See the main [Resources](index.md) overview for more development resources.
-
-
-
+These summaries are only a directory. Read the complete standard, its status,
+and its linked definitions before implementation. For contract development,
+continue with [Smart Contracts](../contracts/index.md); for API details, see
+[References](../references/index.md).

--- a/docs/resources/ecosystem-platforms.md
+++ b/docs/resources/ecosystem-platforms.md
@@ -1,43 +1,60 @@
-# Ecosystem Platforms
+# Ecosystem applications and services
 
-Key platforms and applications in the Koinos ecosystem.
+This page lists live applications and services whose purpose and canonical
+destination were verified. Every entry below is third-party: it is operated
+independently of the Koinos project.
 
-## Overview
+Inclusion is not an endorsement, audit, or guarantee of availability. Before
+connecting a wallet, verify the domain, selected network, contract, assets, and
+operation. Never share a recovery phrase, WIF, or private key.
 
-The Koinos ecosystem includes various platforms for trading, NFTs, and other decentralized applications.
-
-## Major Platforms
-
-### Kollection
-- **Type**: NFT Marketplace
-- **Description**: Primary NFT trading platform on Koinos
-- **Features**: NFT minting, trading, collections
-
-### KoinCity
-- **Type**: Community Platform
-- **Description**: Social platform for the Koinos community
-- **Features**: Community discussions, news, updates
+## Exchange application
 
 ### KoinDX
-- **Type**: Decentralized Exchange
-- **Description**: DEX for trading Koinos tokens
-- **Features**: Token swaps, liquidity pools, yield farming
 
-## DeFi Applications
+[KoinDX](https://koindx.com/) is a decentralized-exchange application for
+swapping Koinos tokens. Follow the application's current interface and
+documentation; this directory does not assess its contracts, prices, or
+liquidity.
 
-- **Lending Protocols**: Decentralized lending and borrowing
-- **Yield Farming**: Liquidity mining opportunities
-- **Staking Platforms**: Token staking services
+- **Maintainer:** KoinDX project.
+- **Ownership:** third-party.
 
-## Developer Tools
+## Bridge
 
-- **Block Explorers**: Blockchain data visualization
-- **Wallet Services**: Custodial and non-custodial wallets
-- **API Providers**: Blockchain data APIs
+### Vortex Bridge
 
-## Next Steps
+[Vortex Bridge](https://vortexbridge.io/) provides a cross-chain bridge
+interface that includes Koinos. Bridge use depends on third-party contracts and
+multiple networks. Confirm the supported route and the current project
+documentation before submitting a transfer.
 
-See the main [Resources](index.md) overview for more ecosystem information.
+- **Maintainer:** Vortex project.
+- **Ownership:** third-party.
 
+## Block-production pools
 
+These services provide interfaces for participating in pooled block production.
+They are not part of the Koinos protocol or the official node software.
 
+- [Fogata](https://fogata.io/) — pool discovery and participation interface
+  maintained by Julián González; related source is available in
+  [joticajulian/fogata](https://github.com/joticajulian/fogata). It is
+  third-party.
+- [BurnKoin](https://burnkoin.com/) — block-production pool interface
+  maintained by the BurnKoin project/Luke Willis. The site links its
+  [pool contracts](https://github.com/lukemwillis/koinos-burn-pool) and
+  [web interface](https://github.com/lukemwillis/koinos-burn-pool-ui)
+  repositories. It is third-party.
+
+This directory makes no claim about rewards, returns, uptime, performance, or
+the safety of funds. For protocol-level block production and Proof of Burn, see
+[Node Operators](../nodes/index.md) and
+[Proof of Burn](../architecture/proof-of-burn.md).
+
+## Request an entry or correction
+
+The list intentionally omits projects whose current site, ownership, purpose, or
+network compatibility could not be independently verified. See
+[Community and learning](community-and-learning.md#propose-a-resources-entry)
+for the evidence required to propose an addition.

--- a/docs/resources/ecosystem-platforms.md
+++ b/docs/resources/ecosystem-platforms.md
@@ -1,8 +1,8 @@
 # Ecosystem applications and services
 
-This page lists live applications and services whose purpose and canonical
-destination were verified. Every entry below is third-party: it is operated
-independently of the Koinos project.
+This page lists live applications, services, and node software whose purpose
+and canonical destination were verified. Each entry identifies whether it is
+community-maintained or third-party.
 
 Inclusion is not an endorsement, audit, or guarantee of availability. Before
 connecting a wallet, verify the domain, selected network, contract, assets, and
@@ -32,6 +32,23 @@ documentation before submitting a transfer.
 - **Maintainer:** Vortex project.
 - **Ownership:** third-party.
 
+## Community applications
+
+### Koin Krew
+
+[Koin Krew](https://koincrew.com/) operates a Koinos community site and
+[application portal](https://app.koincrew.com/) with token-tracking, NFT,
+airdrop, and ownership-verification tools.
+
+- **Maintainer:** Koin Krew project.
+- **Ownership:** third-party.
+- **Source:** no public source repository was verified.
+
+Some features connect a wallet or interact with tokens. Confirm the destination,
+contract, permissions, and transaction contents before using them. This
+directory does not assess the listed tokens, NFTs, prices, or application
+contracts.
+
 ## Block-production pools
 
 These services provide interfaces for participating in pooled block production.
@@ -51,6 +68,41 @@ This directory makes no claim about rewards, returns, uptime, performance, or
 the safety of funds. For protocol-level block production and Proof of Burn, see
 [Node Operators](../nodes/index.md) and
 [Proof of Burn](../architecture/proof-of-burn.md).
+
+## Node software and operator applications
+
+The official Koinos reference node remains the
+[microservice-based Koinos node](https://github.com/koinos/koinos). The
+projects below are community-led, experimental alternatives. Follow the
+[Node Operators](../nodes/index.md) documentation for the standard production
+path.
+
+### Koinos One
+
+[Koinos One](https://github.com/koinos/koinos-one) is an experimental desktop
+application for running and managing a local Koinos node. It uses Teleno as its
+native node engine and currently targets macOS.
+
+- **Maintainer:** community contributors led by Pablo García.
+- **Ownership:** community-maintained; the repository is hosted in the Koinos
+  GitHub organization.
+- **Current reviewed release:** [Koinos One v1.1.1](https://github.com/koinos/koinos-one/releases/tag/v1.1.1).
+
+### Teleno
+
+[Teleno](https://github.com/koinos/teleno) is an experimental,
+Koinos-compatible node implemented as a single native C++ binary. It is the
+node engine used by Koinos One; it does not replace the official
+microservice-based reference implementation.
+
+- **Maintainer:** community contributors led by Pablo García.
+- **Ownership:** community-maintained; the repository is hosted in the Koinos
+  GitHub organization.
+- **Current reviewed release:** [Teleno node 1.1.0](https://github.com/koinos/teleno/releases/tag/teleno-node-v1.1.0).
+
+Verify the selected network, release, configuration, data path, and key-handling
+instructions in each project's own documentation before running either
+experimental project.
 
 ## Request an entry or correction
 

--- a/docs/resources/explorers.md
+++ b/docs/resources/explorers.md
@@ -7,7 +7,7 @@ network or report operational status.
 Inclusion here is not an endorsement or audit. Verify important transaction and
 account information through more than one source when possible.
 
-## Mainnet explorer
+## Mainnet explorers
 
 ### Koinosblocks
 
@@ -20,6 +20,19 @@ accounts, contracts, and names.
 - **Verified network:** Koinos mainnet.
 - **API:** no current maintained public API documentation was verified, so the
   explorer is listed only as a web interface.
+
+### Koinscan
+
+[Koinscan](https://www.koinscan.com/) is a third-party mainnet explorer
+operated by Armana. It supports searches for blocks, transactions, accounts,
+contracts, and tokens, and includes a network view for block-production data.
+
+- **Ownership:** third-party.
+- **Source:** no public source repository was verified.
+- **Verified network:** Koinos mainnet.
+- **API:** no current public API documentation was verified.
+- **Status:** the site identifies itself as an early beta, so independently
+  verify information used for an operational or financial decision.
 
 ## Current public testnet
 

--- a/docs/resources/explorers.md
+++ b/docs/resources/explorers.md
@@ -1,38 +1,48 @@
-# Explorers
+# Explorers and network tools
 
-Blockchain explorers for viewing Koinos transactions, blocks, and addresses.
+Explorers let you inspect public blockchain data without running a local query.
+Network repositories and dashboards serve a different purpose: they describe a
+network or report operational status.
 
-## Overview
+Inclusion here is not an endorsement or audit. Verify important transaction and
+account information through more than one source when possible.
 
-Block explorers provide a web interface to browse and search the Koinos blockchain, view transaction details, account balances, and network statistics.
-
-## Main Explorers
+## Mainnet explorer
 
 ### Koinosblocks
-- **URL**: [https://koinosblocks.com](https://koinosblocks.com)
-- **Features**: Transaction search, block explorer, account details
-- **Testnet**: [https://harbinger.koinosblocks.com](https://harbinger.koinosblocks.com)
 
-### Koiner
-- **URL**: [https://koiner.app](https://koiner.app)  
-- **Features**: Advanced analytics, contract interactions, API access
-- **Testnet**: [https://harbinger.koiner.app](https://harbinger.koiner.app)
+[Koinosblocks](https://koinosblocks.com/) is a community-maintained mainnet
+explorer operated by Engrave. It supports searches for blocks, transactions,
+accounts, contracts, and names.
 
-## Features
+- **Ownership:** community-maintained.
+- **Source:** [Engrave's Koinosblocks repository](https://gitlab.com/engrave/koinos/koinosblocks).
+- **Verified network:** Koinos mainnet.
+- **API:** no current maintained public API documentation was verified, so the
+  explorer is listed only as a web interface.
 
-- **Transaction Search**: Find transactions by hash or address
-- **Block Explorer**: Browse blocks and their contents
-- **Address Lookup**: View account balances and history
-- **Contract Information**: Explore smart contract details
-- **Network Statistics**: Real-time network metrics
+## Current public testnet
 
-## API Access
+No graphical explorer was verified for the current public testnet during this
+review. Use the official
+[koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) repository for
+the current network definition, release information, and connection guidance.
+Do not assume that a mainnet explorer supports the testnet.
 
-Most explorers provide API endpoints for programmatic access to blockchain data.
+Avoid copying network identifiers or endpoints into long-lived integrations.
+Read them from the current official testnet release, then verify the chain ID
+returned by the endpoint before submitting an operation. See
+[Mainnet vs Testnet](../getting-started/mainnet-vs-testnet.md) and
+[Interacting with the testnet](../interacting/testnet.md).
 
-## Next Steps
+## Choosing a network tool
 
-See the main [Resources](index.md) overview for more tools and platforms.
+- Use an **explorer** to inspect blocks, transactions, accounts, and contracts.
+- Use an official **network repository** to identify the current testnet and its
+  configuration.
+- Use the [Node Operators](../nodes/index.md) documentation if you need to run
+  or query your own node.
 
-
-
+Third-party sites can be delayed, incomplete, or unavailable. An explorer's
+display is not proof that a transaction is final; use the finality guidance
+appropriate to your application.

--- a/docs/resources/explorers.md
+++ b/docs/resources/explorers.md
@@ -21,6 +21,42 @@ accounts, contracts, and names.
 - **API:** no current maintained public API documentation was verified, so the
   explorer is listed only as a web interface.
 
+### KoinosScan
+
+[KoinosScan](https://koinosscan.com/) is a community-maintained mainnet
+explorer and analytics platform led by
+[interfecto](https://github.com/interfecto). Its open-source
+[Koinos Token Tracker](https://github.com/koinos/koinos-token-tracker) indexes
+irreversible blocks, token events, balances, transfers, and block metadata.
+
+The current interface provides:
+
+- address and transaction-hash search;
+- recent blocks, transactions, and block-producer information;
+- KOIN and VHP balances, holder rankings, transfer history, and distribution
+  charts;
+- historical KOIN ERC-20 claim analytics, which should be treated as
+  project-provided analysis rather than protocol data.
+
+Verification details:
+
+- **Ownership:** community-maintained; the source repository is hosted in the
+  Koinos GitHub organization.
+- **Reviewed source:** commit
+  [`c625f58`](https://github.com/koinos/koinos-token-tracker/commit/c625f58aba806eb821036cd27fcea26ebbedfd7d).
+- **Verified network:** Koinos mainnet.
+- **API:** the current
+  [Token Tracker API documentation](https://api.koinosscan.com/) covers
+  indexed addresses, token holders, transfers, blocks, tokens, and indexer
+  status. It is not a general-purpose Koinos node API.
+- **Synchronization:** the indexer intentionally processes blocks through the
+  last irreversible block, so its displayed height normally trails the chain
+  head by about 60 blocks.
+
+Market information and historical-claim classifications can depend on external
+data or project-defined heuristics. Verify consequential information against
+on-chain data and the methodology shown by the project.
+
 ### Koinscan
 
 [Koinscan](https://www.koinscan.com/) is a third-party mainnet explorer

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,152 +1,92 @@
----
-hide:
-- navigation
----
-
 # Resources
-In the resources section of the Koinos documentation, you'll find a wealth of supplementary materials to further enhance your understanding and development experience with the Koinos blockchain. Explore links to community forums, developer blogs, and video tutorials that provide insights into best practices, troubleshooting tips, and real-world use cases. Access additional documentation, SDKs, and tools to accelerate your development journey and engage with the vibrant Koinos community to collaborate, share knowledge, and stay updated on the latest developments within the ecosystem.
 
-## Koinos is Open Source
-All standard microservice code and SDKs are available in its entirety and completely open source.
+This directory helps users and developers find Koinos software, applications,
+standards, and community material. It is a directory of links, not a substitute
+for each project's own documentation.
 
-<div class="grid cards" markdown>
+Looking for the blockchain's Resource Credits and Mana model instead? See
+[Resources in Architecture](../architecture/resources.md).
 
--   :fontawesome-brands-github:{ .lg .middle } __Koinos organization__
+!!! info "How entries are classified"
 
-    ---
+    **Official** resources are maintained by the Koinos project.
+    **Community-maintained** resources are open projects maintained by community
+    contributors. **Third-party** resources are operated independently of the
+    Koinos project.
 
-    The Koinos blockchain is open source and completely decentralized and we encourage all developers to contribute code to improve the Koinos ecosystem.
+    Inclusion is not an endorsement, audit, or guarantee of availability. Verify
+    the destination, selected network, transaction details, and current project
+    documentation before connecting a wallet or signing.
 
-    [:octicons-arrow-right-24: Read the code](https://github.com/koinos)
-</div>
-
-## Cryptocurrency wallets
-Wallets play a crucial role in the Koinos blockchain ecosystem, providing a secure and user-friendly interface for managing Koinos tokens (KOIN) and interacting with decentralized applications (dApps). Koinos wallets enable users to send and receive KOIN, delegate resources, and interact with smart contracts, offering a seamless and intuitive experience for engaging with the blockchain.
-
-<div class="grid cards" markdown>
-
--   :fontawesome-solid-terminal:{ .lg .middle } __Koinos CLI__
-
-    ---
-
-    The Koinos CLI is a command line tool for interacting with the Koinos blockchain.
-
-    [:octicons-arrow-right-24: I'm a power user](https://github.com/koinos/koinos-cli)
-
--   :fontawesome-brands-chrome:{ .lg .middle } __Kondor__
-
-    ---
-
-    The Kondor chrome extension is a wallet that allows users to interact with web based dApps with ease.
-
-    [:octicons-arrow-right-24: I want convenience](https://chromewebstore.google.com/detail/ghipkefkpgkladckmlmdnadmcchefhjl)
-
--   :fontawesome-solid-mobile:{ .lg .middle } __Konio__
-
-    ---
-
-    Konio is a wallet designed for mobile phone operating systems such as Android and iPhone.
-
-    [:octicons-arrow-right-24: I'm on the move](https://konio.io/)
-
--   :fontawesome-solid-credit-card:{ .lg .middle } __Tangem__
-
-    ---
-
-    Tangem is a hardware wallet in the form factor of a credit card.
-
-    [:octicons-arrow-right-24: I want security](https://tangem.com/)
-</div>
-
-## Contract standards
-Standards provide guidelines and information for developers to utilize so that their contributions to Koinos can fully take advantage of the entire ecosystem.
+## For users
 
 <div class="grid cards" markdown>
 
--   :fontawesome-solid-book:{ .lg .middle } __Koinos Contract Standards__
+-   :fontawesome-solid-wallet:{ .lg .middle } __Wallets__
 
     ---
 
-    The Koinos Contract Standards (KCS) provide a framework for smart contracts to faciliate the interoperability of all decentralized applications in the Koinos ecosystem.
+    Compare verified wallet options, platforms, key models, and dApp support.
 
-    [:octicons-arrow-right-24: Understand Koinos Contract Standards](https://github.com/koinos/koinos-contract-standards)
+    [:octicons-arrow-right-24: Compare wallets](wallets.md)
+
+-   :fontawesome-solid-magnifying-glass:{ .lg .middle } __Explorers and network tools__
+
+    ---
+
+    Find verified tools for inspecting blocks, transactions, accounts, and
+    current network information.
+
+    [:octicons-arrow-right-24: Inspect the network](explorers.md)
+
+-   :fontawesome-solid-shapes:{ .lg .middle } __Applications and services__
+
+    ---
+
+    Browse verified third-party exchange, bridge, and block-production-pool
+    applications.
+
+    [:octicons-arrow-right-24: Browse applications](ecosystem-platforms.md)
+
 </div>
 
-## Ecosystem platforms
-The platforms on the Koinos blockchain offer developers a robust and scalable environment to build and deploy innovative decentralized applications. Integrating your dApp with various existing platforms may boost your visibile and add cohesion to the Koinos ecosystem.
+## For developers
 
 <div class="grid cards" markdown>
 
--   :fontawesome-solid-coins:{ .lg .middle } __Kollection__
+-   :fontawesome-solid-code:{ .lg .middle } __SDKs, libraries, and developer tools__
 
     ---
 
-    Kollection is a full featured Non-Fungible-Token (NFT) marketplace that allows creators to launch and sell their products.
+    Choose current tools for blockchain interaction, contract development, local
+    testing, CLI use, and protocol schemas.
 
-    [:octicons-arrow-right-24: I'm a power user](https://kollection.app/)
+    [:octicons-arrow-right-24: Find developer tools](software-libraries.md)
 
--   :fontawesome-solid-rocket:{ .lg .middle } __KoinCity__
-
-    ---
-
-    KoinCity is a token launchpad with numerous features including token launches, staking, marketplace, and social interaction.
-
-    [:octicons-arrow-right-24: Launch a token](https://koincity.com/)
-
--   :material-swap-horizontal-bold:{ .lg .middle } __KoinDX__
+-   :fontawesome-solid-file-code:{ .lg .middle } __Contract standards__
 
     ---
 
-    KoinDX is the world's first decentralization exchange built on the Koinos blockchain.
+    Check the exact titles, purposes, and current statuses of the Koinos Contract
+    Standards.
 
-    [:octicons-arrow-right-24: I want convenience](https://koindx.com/)
-</div>
-
-## Software libraries
-Libraries allow users to interact with the Koinos blockchain programmatically in a variety of ways but most notably through web technologies.
-
-<div class="grid cards" markdown>
-
--   :fontawesome-brands-js:{ .lg .middle } __Koilib__
-
-    ---
-
-    Koilib is a full featured JavaScript library that faciliates interactions with the Koinos blockchain.
-    <br/><br/><br/>
-
-    [:octicons-arrow-right-24: The premier Koinos JavaScript library](https://www.npmjs.com/package/koilib)
-
--   :fontawesome-solid-rocket:{ .lg .middle } __Arkinos__
-
-    ---
-
-    This is a new tool that dramatically simplifies contract development on Koinos. You can create a new contract and have a website to interact with it in less than 5 minutes!
-
-    [:octicons-arrow-right-24: Launch a frontend with smart contract](https://www.npmjs.com/package/arkinos)
+    [:octicons-arrow-right-24: Review contract standards](contract-standards.md)
 
 </div>
 
-## Software Development Kits
-Software Development Kits (SDKs) provide compilers, debugging, testing frameworks, and libraries for the development of Koinos smart contracts and can come in a variety of languages.
+## Community and learning
 
-<div class="grid cards" markdown>
+Use [Community and learning](community-and-learning.md) to find official
+channels, contribution paths, articles, videos, and instructions for reporting
+stale documentation or proposing a directory entry.
 
--   :fontawesome-brands-js:{ .lg .middle } __AssemblyScript__
+## Related documentation
 
-    ---
-
-    The Koinos AssemblyScript SDK is among the most popular among Koinos developers. It provides an easy to use API in a language that many developers are already familiar with.
-    <br/><br/>
-
-    [:octicons-arrow-right-24: Build with AssemblyScript](https://github.com/koinos/koinos-sdk-as)
-
--   :fontawesome-solid-c:{ .lg .middle } __C++__
-
-    ---
-
-    The Koinos C++ SDK is a powerful toolkit that allows for the development of smart contracts in C++. While it is currently less popular than alternatives, many system level smart contracts are implemented using it.
-    <br/><br/>
-
-    [:octicons-arrow-right-24: I'm an expert, I know what I'm doing](https://github.com/koinos/koinos-sdk-cpp)
-
-</div>
+- [Getting Started](../getting-started/index.md) covers accounts, keys, wallets,
+  networks, and first transactions.
+- [Interacting with Koinos](../interacting/index.md) covers wallet and API
+  workflows.
+- [Smart Contracts](../contracts/index.md) covers contract development.
+- [Node Operators](../nodes/index.md) covers running Koinos infrastructure.
+- [Architecture](../architecture/index.md) explains how Koinos works.
+- [References](../references/index.md) contains API and SDK reference material.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -43,8 +43,8 @@ Looking for the blockchain's Resource Credits and Mana model instead? See
 
     ---
 
-    Browse verified third-party exchange, bridge, and block-production-pool
-    applications.
+    Browse verified exchange, bridge, community, block-production-pool, and
+    node-software projects.
 
     [:octicons-arrow-right-24: Browse applications](ecosystem-platforms.md)
 

--- a/docs/resources/software-libraries.md
+++ b/docs/resources/software-libraries.md
@@ -1,91 +1,114 @@
-# Software Libraries
+# SDKs, libraries, and developer tools
 
-Development libraries and tools for building on Koinos.
+Choose tools by the task you need to perform. Versions shown here were verified
+on **2026-07-25**; check the canonical package or repository before installing.
+An official repository is maintained in the Koinos GitHub organization. A
+community-maintained project has an independent maintainer.
 
-## Overview
-
-A collection of libraries, SDKs, and tools to help developers build applications and interact with the Koinos blockchain.
-
-## Core Libraries
+## JavaScript and TypeScript interaction
 
 ### Koilib
-- **Language**: JavaScript/TypeScript
-- **Purpose**: Primary SDK for web applications
-- **Repository**: [GitHub](https://github.com/koinos/koilib)
-- **Installation**: `npm install koilib`
 
-### Koinos SDK (AssemblyScript)
-- **Language**: AssemblyScript
-- **Purpose**: Smart contract development
-- **Repository**: [GitHub](https://github.com/koinos/koinos-sdk-as)
-- **Installation**: `npm install @koinos/sdk-as`
+[Koilib](https://github.com/joticajulian/koilib) is a
+community-maintained JavaScript/TypeScript library for providers, signers,
+transactions, contracts, and serialization.
 
-## Language-Specific Libraries
+```console
+npm install koilib
+```
 
-### Python
-- **koinos-python**: Python SDK for Koinos interaction
-- **Features**: Transaction building, contract calls, wallet management
+- **Published package:** [`koilib` 9.2.0](https://www.npmjs.com/package/koilib)
+- **Reviewed source:** commit
+  [`ae5b267`](https://github.com/joticajulian/koilib/commit/ae5b2671ee5f31cb9c8f66f3007a4451026d3ec7)
+- **Maintainer:** Julián González
 
-### Go
-- **koinos-go**: Go SDK for Koinos
-- **Features**: Node integration, blockchain interaction
+See the [Koilib reference](../references/koilib/contract-class.md) and
+[Interacting with Koinos](../interacting/index.md) for the relevant workflows.
 
-### Rust
-- **koinos-rust**: Rust SDK (community-maintained)
-- **Features**: High-performance blockchain interaction
+## AssemblyScript contracts
 
-## Development Tools
+### Koinos AssemblyScript SDK
 
-### Arkinos
-- **Purpose**: Smart contract development framework
-- **Features**: Project scaffolding, testing, deployment
-- **Installation**: `npm install -g @arkinos/cli`
+The official [Koinos AssemblyScript SDK](https://github.com/koinos/koinos-sdk-as)
+provides the contract APIs and types used to build AssemblyScript smart
+contracts.
 
-### Koinos CLI
-- **Purpose**: Command-line blockchain interaction
-- **Features**: Wallet management, contract deployment, transactions
-- **Installation**: Available as binary download
+```console
+npm install @koinos/sdk-as
+```
 
-## Testing Libraries
+- **Published package:**
+  [`@koinos/sdk-as` 1.4.0](https://www.npmjs.com/package/@koinos/sdk-as)
+- **Reviewed source:** commit
+  [`d93ad34`](https://github.com/koinos/koinos-sdk-as/commit/d93ad345a34fa65bfd7a25ec5fc3c7ad9d428f21)
 
-### Koinos Mock VM
-- **Purpose**: Local contract testing
-- **Features**: Simulate blockchain environment for testing
+The official
+[AssemblyScript SDK CLI](https://github.com/koinos/koinos-sdk-as-cli) scaffolds
+and manages AssemblyScript contract projects:
 
-### Integration Test Framework
-- **Purpose**: End-to-end testing
-- **Features**: Full blockchain simulation for comprehensive testing
+```console
+npm install --global @koinos/sdk-as-cli
+```
 
-## Utility Libraries
+The published package is
+[`@koinos/sdk-as-cli` 1.0.2](https://www.npmjs.com/package/@koinos/sdk-as-cli);
+the reviewed repository revision is
+[`6c0a7cb`](https://github.com/koinos/koinos-sdk-as-cli/commit/6c0a7cb18533a02e442998de0d4575e263077b34).
+Follow [Smart Contracts](../contracts/index.md) for the complete development
+workflow.
 
-### Koinos Protobuf
-- **Purpose**: Protocol buffer definitions
-- **Usage**: Data serialization and contract interfaces
+## C++ contracts
 
-### Koinos Types
-- **Purpose**: TypeScript type definitions
-- **Usage**: Type safety for Koinos development
+The official [Koinos C++ SDK](https://github.com/koinos/koinos-sdk-cpp)
+provides a C++ smart-contract development kit. Its latest GitHub release at the
+time of review is
+[`v1.0.0`](https://github.com/koinos/koinos-sdk-cpp/releases/tag/v1.0.0).
+Review its build instructions and compatibility with your target chain release
+before starting a new project.
 
-## Community Libraries
+## Command-line interaction
 
-### Wallet Connectors
-- **Purpose**: Standardized wallet integration
-- **Features**: Multi-wallet support, consistent APIs
+The official [Koinos CLI](https://github.com/koinos/koinos-cli) manages
+accounts, reads chain state, invokes contracts, and submits transactions. Use
+the documented release rather than an unversioned binary; the release verified
+for this review is
+[`v2.0.0`](https://github.com/koinos/koinos-cli/releases/tag/v2.0.0).
 
-### Contract Utilities
-- **Purpose**: Common contract patterns
-- **Features**: Reusable contract components
+CLI operations can be state-changing. Verify the endpoint, chain ID, account,
+operation, and signer before approving a transaction. Start with the
+[CLI wallet guide](../getting-started/cli-wallet.md).
 
-## Getting Started
+## Local testing
 
-1. **Choose your language** and install the appropriate SDK
-2. **Review documentation** and examples
-3. **Start with simple examples** to understand the basics
-4. **Join the community** for support and updates
+- The official
+  [Koinos local testnet](https://github.com/koinos/koinos-local-testnet)
+  starts a development network for local integration testing. The reviewed
+  source is commit
+  [`2508a39`](https://github.com/koinos/koinos-local-testnet/commit/2508a39826d6632238edd8a1138c1b42c7ca8cbd).
+  A local network is separate from the current public testnet.
+- The official
+  [Koinos Mock VM](https://github.com/koinos/koinos-mock-vm) supports local
+  contract unit tests. The verified package is
+  [`@koinos/mock-vm` 1.2.0](https://www.npmjs.com/package/@koinos/mock-vm), and
+  the reviewed source is commit
+  [`b7bcd44`](https://github.com/koinos/koinos-mock-vm/commit/b7bcd4483447c0d70529ff9d4d5fe4dd5d6b25e7).
 
-## Next Steps
+A mock runtime does not replace testing against the target integration network.
+For the current public testnet, use the official
+[koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) source and the
+[testnet guide](../interacting/testnet.md).
 
-See the main [Resources](index.md) overview for more development resources.
+## Protocol schemas and generated types
 
+The official [koinos-proto](https://github.com/koinos/koinos-proto) repository
+contains Koinos Protocol Buffer schemas and generated bindings. The version
+reviewed here is
+[`v2.6.0`](https://github.com/koinos/koinos-proto/releases/tag/v2.6.0).
 
+Generated C++, embedded C++, Go, JavaScript, and Python bindings expose
+protocol-level messages. They are not complete high-level SDKs: application
+features such as signing, provider behavior, transaction construction, and
+contract abstractions must be evaluated separately.
 
+See [Protocol Buffers](../contracts/protobuffers.md) and
+[References](../references/index.md) for related documentation.

--- a/docs/resources/wallets.md
+++ b/docs/resources/wallets.md
@@ -1,0 +1,69 @@
+# Wallets
+
+Wallets manage the keys used to authorize Koinos operations. The entries below
+were verified through their current canonical sources, but their inclusion is
+not an endorsement or security audit.
+
+## Comparison
+
+<div class="grid cards" markdown>
+
+-   __[Kondor](https://kondorwallet.com/)__
+
+    ---
+
+    - **Platform:** Chromium browser extension.
+    - **Key model:** self-custody; keys are managed by the extension.
+    - **dApp support:** compatible web applications can request signatures.
+    - **Networks:** Koinos; confirm the selected provider and network before
+      signing.
+    - **Maintainer:** [Julián González](https://github.com/joticajulian).
+    - **Ownership:** community-maintained.
+    - **Source:** [joticajulian/kondor](https://github.com/joticajulian/kondor).
+
+    Use the install link from the canonical website and verify the extension
+    publisher before installing.
+
+-   __[Tangem](https://tangem.com/en/cryptocurrencies/koinos/)__
+
+    ---
+
+    - **Platform:** Tangem cards and mobile application.
+    - **Key model:** keys are managed through the Tangem hardware-wallet
+      system.
+    - **dApp support:** no Koinos dApp-browser support was verified for this
+      review.
+    - **Networks:** Tangem's current asset page lists the Koinos network.
+    - **Maintainer:** Tangem.
+    - **Ownership:** third-party.
+    - **Source availability:** no open-source repository for the Koinos
+      integration was verified during this review.
+
+</div>
+
+## Command-line alternative
+
+The official [Koinos CLI](https://github.com/koinos/koinos-cli) can manage
+accounts and submit transactions from a terminal. It is listed primarily under
+[SDKs, libraries, and developer tools](software-libraries.md), rather than as a
+consumer wallet. See the [CLI wallet guide](../getting-started/cli-wallet.md)
+before using it.
+
+## Protect keys and recovery material
+
+!!! danger "Never share wallet secrets"
+
+    A recovery phrase, WIF, or private key gives control of the associated
+    account. Never paste one into documentation, chat, an issue, a website, or a
+    command you have not independently verified. Koinos contributors and wallet
+    maintainers should not ask for it.
+
+- Back up recovery material offline before funding an account.
+- Verify the wallet URL, extension publisher, network, recipient, and operation
+  before approving a signature.
+- Test recovery with the wallet's current instructions before relying on a
+  backup.
+- Use a separate low-value account when evaluating an unfamiliar application.
+
+For the account, key, and wallet concepts behind these precautions, read
+[Accounts, Keys, and Wallets](../getting-started/accounts-keys-wallets.md).

--- a/docs/resources/wallets.md
+++ b/docs/resources/wallets.md
@@ -41,7 +41,54 @@ not an endorsement or security audit.
 
 </div>
 
-## Command-line alternative
+## Command-line wallets
+
+Command-line wallets are intended for users who can inspect source,
+dependencies, terminal history, file permissions, networks, and transaction
+details. Test a tool with a separate low-value testnet account before deciding
+whether it is appropriate for other keys.
+
+### kcli
+
+[kcli](https://github.com/pgarciagon/kcli) is a community-maintained Node.js
+command-line wallet and blockchain interaction tool built with Koilib.
+
+- **Platform:** terminal application built from source with Node.js.
+- **Key model:** self-custody; an imported WIF is password-encrypted in a local
+  wallet file.
+- **dApp support:** no browser dApp connection; it reads chain data and submits
+  supported transactions directly.
+- **Networks:** mainnet and the current public testnet are implemented. In the
+  reviewed version, a saved RPC can override the selected network, so verify
+  both the displayed RPC and its chain ID before signing.
+- **Maintainer:** [Pablo García](https://github.com/pgarciagon).
+- **Ownership:** community-maintained.
+- **Source:** [pgarciagon/kcli](https://github.com/pgarciagon/kcli).
+- **Reviewed version:** `1.4.0` at commit
+  [`c263df6`](https://github.com/pgarciagon/kcli/commit/c263df637eb632e275e77f807777aa64c3fd54ed).
+
+!!! warning "Review kcli before using a funded account"
+
+    The reviewed version has no published release or package; install it from
+    source. Some commands accept a WIF or recovery phrase as a command-line
+    argument, and wallet generation prints the WIF in the terminal. Those
+    values can be exposed through terminal history, process inspection,
+    recordings, or logs.
+
+    A production-dependency audit of the reviewed commit also reported known
+    advisories, including
+    [a critical advisory in a transitive dependency](https://github.com/advisories/GHSA-xq3m-2v4x-88gg).
+    Review and update the dependency tree before relying on it, and prefer a
+    low-value testnet account while evaluating the tool.
+
+    During verification, a saved mainnet RPC overrode `--network testnet` for
+    a read command, which then displayed mainnet data under a testnet label.
+    Use the current endpoint from
+    [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet)
+    explicitly and verify the returned chain ID. Do not rely on the network
+    label alone.
+
+### Koinos CLI
 
 The official [Koinos CLI](https://github.com/koinos/koinos-cli) can manage
 accounts and submit transactions from a terminal. It is listed primarily under

--- a/drafts/resources/RESOURCE_DOCUMENTATION_PLAN.md
+++ b/drafts/resources/RESOURCE_DOCUMENTATION_PLAN.md
@@ -1,0 +1,636 @@
+# Resources Documentation Update Plan
+
+## Status
+
+Internal implementation plan. This file is not part of the published MkDocs
+content.
+
+No public page, navigation entry, or cross-chapter link is changed by this
+plan. Implementation must happen later on a dedicated feature branch.
+
+## Objective
+
+Rebuild the top-level Koinos **Resources** section as a current, trustworthy,
+and maintainable directory of tools, services, standards, projects, and
+community material.
+
+The section must help readers discover resources without:
+
+- duplicating tutorials and technical explanations from other chapters;
+- presenting third-party projects as officially endorsed;
+- preserving obsolete testnet information;
+- listing tools, SDKs, APIs, or features that have not been verified;
+- making unsupported security, reliability, liquidity, or performance claims;
+- confusing this directory with the Koinos Resource Credits and Mana model.
+
+The technical resource-accounting model remains in
+[Architecture](../../docs/architecture/resources.md). This plan concerns the
+separate top-level directory under `docs/resources/`.
+
+## Ownership and Git workflow
+
+The Resources chapter is assigned to `pgarcgo`.
+
+Implementation must:
+
+1. Read and follow `AGENTS.local.md`.
+2. Preserve all unrelated tracked and untracked files.
+3. Fetch the latest `origin/dev`.
+4. Create a new branch named `codex/update-resources-docs` from `origin/dev`.
+5. Keep the work independent from the Architecture feature branch.
+6. Limit cross-chapter edits to necessary navigation or link corrections.
+7. Call out every cross-chapter file in the pull-request description.
+8. Open a draft pull request targeting `dev`.
+9. Do not merge the pull request or mark it ready for review.
+
+If the Architecture pull request has not yet merged, the Resources branch must
+still start from `origin/dev`. Do not stack the Resources work on the
+Architecture branch.
+
+## Current-state findings
+
+### Published `master`
+
+The published Resources section currently consists of one large landing page:
+
+- `docs/resources/index.md`
+
+It mixes wallets, ecosystem applications, standards, libraries, SDKs, and
+general promotional text in a single page. It contains duplicated material,
+outdated descriptions, spelling errors, subjective calls to action, and claims
+that are difficult to maintain.
+
+### Current `dev`
+
+The `dev` branch adds these child pages:
+
+- `docs/resources/wallets.md`
+- `docs/resources/explorers.md`
+- `docs/resources/ecosystem-platforms.md`
+- `docs/resources/contract-standards.md`
+- `docs/resources/software-libraries.md`
+
+The current problems include:
+
+- `wallets.md` is empty.
+- `explorers.md` still links to the retired Harbinger testnet.
+- `contract-standards.md` assigns invented purposes to KCS-3, KCS-4, and KCS-5.
+- `software-libraries.md` lists Python, Go, and Rust SDKs without canonical
+  repositories or sufficient evidence that they exist as supported high-level
+  SDKs.
+- `ecosystem-platforms.md` contains generic DeFi categories without identifying
+  verified live Koinos applications.
+- Several descriptions are promotional rather than factual.
+- The landing page repeats information that should live in the child pages.
+- The landing page hides navigation, making its child pages harder to discover.
+- The home-page card named “References & Resources” links to References, not to
+  the Resources section.
+
+## Source-of-truth policy
+
+### First-party technical sources
+
+Use current, versioned sources from:
+
+- [Koinos GitHub organization](https://github.com/koinos)
+- [Koinos documentation repository](https://github.com/koinos/koinos-docs)
+- [Koinos public testnet](https://github.com/koinos/koinos-testnet)
+- [Koinos Contract Standards](https://github.com/koinos/koinos-contract-standards)
+- official package registries linked from the corresponding repositories
+
+For SDKs, libraries, schemas, and standards, record both:
+
+- an immutable tag or commit that supports the documented statement; and
+- the canonical project page where readers can find the newest release.
+
+### Ecosystem discovery sources
+
+The [Koinos ecosystem page](https://koinos.io/ecosystem) may be used to discover
+candidate projects, but it is not sufficient evidence by itself. Every
+third-party candidate must be checked against its own canonical website,
+repository, package, or application.
+
+### Current-testnet policy
+
+The only testnet described as current must be the testnet documented by
+`koinos/koinos-testnet`.
+
+Do not:
+
+- restore Harbinger links;
+- copy historical chain IDs, contract addresses, serialized transactions,
+  nonces, signatures, or resource limits;
+- claim that an explorer supports the current testnet without verifying its
+  current chain and endpoint;
+- embed operational testnet details that belong in Getting Started or Node
+  Operators.
+
+### Explicit exclusions
+
+- Do not add or restore references to Sovrano.
+- Do not present archived, unreachable, or unverified projects as current.
+- Do not imply that inclusion is an audit, endorsement, or security guarantee.
+- Do not add investment recommendations or claims about yields, liquidity, or
+  returns.
+
+## Proposed information architecture
+
+Keep the existing URLs where possible to avoid unnecessary redirects, but
+present the navigation with explicit audience-oriented labels:
+
+```text
+Resources
+├── Resources overview
+├── For users
+│   ├── Wallets
+│   ├── Explorers and network tools
+│   └── Ecosystem applications and services
+├── For developers
+│   ├── SDKs, libraries, and developer tools
+│   └── Contract standards
+└── Community and learning
+```
+
+Recommended paths:
+
+| Navigation label | Path | Action |
+| --- | --- | --- |
+| Resources overview | `docs/resources/index.md` | Rewrite |
+| Wallets | `docs/resources/wallets.md` | Fill and verify |
+| Explorers and network tools | `docs/resources/explorers.md` | Correct and extend |
+| Ecosystem applications and services | `docs/resources/ecosystem-platforms.md` | Correct and reorganize |
+| SDKs, libraries, and developer tools | `docs/resources/software-libraries.md` | Rewrite; retain path |
+| Contract standards | `docs/resources/contract-standards.md` | Rewrite from canonical KCS data |
+| Community and learning | `docs/resources/community-and-learning.md` | Add |
+
+Do not add separate Resources pages for:
+
+- Resource Credits or Mana;
+- API tutorials;
+- testnet setup;
+- node operation;
+- smart-contract tutorials;
+- exchange integration.
+
+Those subjects must remain in their owning chapters, with links from Resources
+where useful.
+
+## Internal inventory
+
+Before changing public pages, create:
+
+```text
+drafts/resources/
+├── RESOURCE_DOCUMENTATION_PLAN.md
+└── RESOURCE_INVENTORY.md
+```
+
+`RESOURCE_INVENTORY.md` should record one row per candidate:
+
+| Field | Purpose |
+| --- | --- |
+| Name | Canonical product or project name |
+| Category | Wallet, explorer, SDK, standard, dApp, community, or service |
+| Maintainer | Responsible organization or account |
+| Ownership | Koinos, community, or third party |
+| Canonical URL | Primary website or documentation |
+| Repository | Source repository when available |
+| Version evidence | Tag or commit supporting technical statements |
+| Network | Mainnet, current public testnet, local, or unknown |
+| Platform/language | Browser, mobile, hardware, JavaScript, C++, and so on |
+| Last verification | Date of the evidence check |
+| Status | Include, exclude, or pending |
+| Notes | Limitations, redirects, missing evidence, or maintenance concerns |
+
+### Inclusion checks
+
+A resource may be published only when:
+
+1. Koinos support is explicit and verifiable.
+2. Its canonical URL resolves over HTTPS.
+3. Its description can be supported by a primary source.
+4. Its maintainer or ownership can be identified.
+5. Its network compatibility is known or clearly marked as unknown.
+6. It provides current value to Koinos users or developers.
+7. The documentation can describe it without making an endorsement.
+
+Links that return `403` to automated clients require a manual browser check;
+they must not automatically be classified as dead. Redirects must resolve to
+the expected organization and product.
+
+## Page implementation
+
+### 1. Resources overview
+
+Rewrite `docs/resources/index.md` as an orientation page.
+
+It should:
+
+- define the section as a directory of tools and ecosystem resources;
+- distinguish it from Architecture’s resource-accounting page;
+- let readers choose a destination by task;
+- link to all Resources child pages;
+- distinguish official, community, and third-party material;
+- include a concise non-endorsement and security notice;
+- link to the official GitHub organization and current public-testnet source;
+- avoid duplicating the detailed lists from the child pages;
+- remove `hide: navigation` unless there is a verified accessibility reason to
+  keep it;
+- replace subjective calls to action with descriptive link labels.
+
+### 2. Wallets
+
+Fill `docs/resources/wallets.md` with a factual comparison.
+
+Recommended fields:
+
+| Field | Example values |
+| --- | --- |
+| Platform | Browser extension, mobile, hardware, or CLI |
+| Key model | Non-custodial, custodial, or not verified |
+| dApp connection | Supported, unsupported, or limited |
+| Network support | Mainnet and/or verified current testnet |
+| Source availability | Public repository or proprietary |
+| Maintainer | Named organization or community project |
+| Canonical link | Verified installation or project page |
+
+Implementation rules:
+
+- verify Kondor and Konio against current canonical sources;
+- include Tangem only if Tangem or another authoritative source currently
+  confirms KOIN support;
+- place Koinos CLI primarily in developer tools, with only a cross-reference
+  from wallets;
+- exclude Sovrano;
+- link to the Getting Started account, key, and wallet guidance rather than
+  duplicating procedures;
+- warn readers never to enter a recovery phrase, WIF, or production private key
+  into an untrusted page, example, or public runner;
+- do not rank wallets by security without an independent, current audit.
+
+### 3. Explorers and network tools
+
+Rewrite `docs/resources/explorers.md`.
+
+It should:
+
+- remove every Harbinger URL;
+- verify each explorer’s mainnet and current-testnet support separately;
+- distinguish explorer, analytics platform, and network dashboard;
+- link directly to canonical products;
+- list API access only when current API documentation exists;
+- avoid generic claims such as “most explorers provide APIs”;
+- avoid copying volatile chain IDs and endpoints;
+- link to the current testnet source for authoritative network details.
+
+Potential candidates must be evaluated, not automatically included:
+
+- Koinosblocks;
+- Koiner;
+- Koinosscan;
+- Koinscan;
+- other current tools found through official and community sources.
+
+### 4. Ecosystem applications and services
+
+Rewrite `docs/resources/ecosystem-platforms.md` around verified live categories:
+
+- exchanges and swaps;
+- NFT applications;
+- names and identity;
+- bridges;
+- block-production pools;
+- governance and community applications;
+- games and other dApps.
+
+For every entry:
+
+- identify it as third-party unless it is demonstrably first-party;
+- describe its actual function in one neutral sentence;
+- name its supported network only when verified;
+- avoid claims about security, performance, liquidity, rewards, or reliability;
+- omit categories that do not contain a verified current application.
+
+Do not preserve generic placeholders such as lending, borrowing, yield farming,
+or staking services when no specific current product and source are available.
+
+### 5. Contract standards
+
+Rewrite `docs/resources/contract-standards.md` from the canonical KCS
+repository.
+
+The current verified baseline is:
+
+| Standard | Canonical title | Status |
+| --- | --- | --- |
+| KCS-1 | Token Standard | Final |
+| KCS-2 | NFT Collection Standard | Final |
+| KCS-3 | Token Standard that mimics ERC-20 | Final |
+| KCS-4 | Token Standard that mimics ERC-20 and supports Koinos authority | Pending |
+| KCS-5 | NFT Standard that mimics ERC-721 and supports Koinos authority | Pending |
+
+Before implementation, refresh this table from the current repository.
+
+Each public entry should include:
+
+- exact title;
+- current status;
+- one concise statement of purpose;
+- an immutable link to the reviewed version;
+- a link to the canonical repository for the latest state.
+
+Do not reproduce exhaustive interfaces or specifications. Do not describe
+KCS-3 as a DEX standard, KCS-4 as a staking standard, or KCS-5 as a governance
+standard.
+
+### 6. SDKs, libraries, and developer tools
+
+Retain `docs/resources/software-libraries.md` to preserve the URL, but use
+“SDKs, libraries, and developer tools” as its navigation label and page title.
+
+Organize entries by task:
+
+- interact with Koinos from JavaScript or TypeScript;
+- develop AssemblyScript contracts;
+- develop C++ contracts;
+- use Koinos CLI;
+- test contracts or chains locally;
+- work with protocol buffers and generated types.
+
+Every entry should include:
+
+- language or runtime;
+- intended task;
+- maintainer;
+- official or community status;
+- canonical repository;
+- documentation;
+- current package or release when verified.
+
+Remove:
+
+- alleged high-level Python, Go, or Rust SDKs without canonical evidence;
+- package names or installation commands that have not been tested;
+- placeholder tooling;
+- promotional claims about development speed;
+- abandoned tools presented as current.
+
+Do not treat low-level protobuf packages as complete application SDKs.
+
+### 7. Community and learning
+
+Add `docs/resources/community-and-learning.md`.
+
+Include only verified:
+
+- official support and announcement channels;
+- GitHub contribution entry points;
+- blog and video resources;
+- developer discussion channels;
+- community-created learning resources;
+- instructions for reporting stale documentation;
+- instructions for proposing a resource for inclusion.
+
+Clearly label official and community-managed channels. Avoid listing private,
+inactive, or unmoderated groups as official support.
+
+## Cross-chapter integration
+
+Keep cross-chapter changes narrow.
+
+Recommended links:
+
+- Getting Started for accounts, keys, wallets, networks, and testnet basics;
+- Interacting with Koinos for API and Koilib usage;
+- Smart Contract Development for tutorials and SDK workflows;
+- Node Operators for running and maintaining nodes;
+- Architecture for the Resource Credits and Mana accounting model;
+- References for API and SDK method-level documentation.
+
+Home-page correction:
+
+- split the current “References & Resources” card into separate destinations;
+  or
+- add a distinct “Tools & ecosystem” card pointing to `resources/index.md`.
+
+Do not edit the content of Julián’s chapters. Only add or correct links that are
+necessary for Resources discoverability, and list those changes explicitly in
+the pull request.
+
+## Executable-example policy
+
+Resources should be a directory, not a code tutorial. Prefer links to existing
+guides and complete examples over new code snippets.
+
+If implementation adds a JavaScript example, it must follow
+`EXECUTABLE_JAVASCRIPT_EXAMPLES_PLAN.md`:
+
+- the complete executable source is canonical;
+- the documentation links to the complete file;
+- it includes a working Run, Codespaces, or justified local-run link;
+- dependencies use exact versions;
+- network and safety behavior are explicit;
+- signing or state-changing examples default to the current testnet and require
+  explicit user approval;
+- no WIF, recovery phrase, or production secret is embedded or requested in a
+  public runner;
+- permanent links target the branch that publishes the documentation, not a
+  disposable feature branch.
+
+Installation commands are permitted only after they have been checked against
+the current canonical package.
+
+## Writing and presentation rules
+
+- Use clear English.
+- Prefer direct descriptions over promotional slogans.
+- Use “third-party” or “community-maintained” where appropriate.
+- Do not call a product secure, trusted, audited, official, primary, premier,
+  best, or most popular without authoritative evidence.
+- Do not imply that Koinos or the Koinos Community Foundation endorses listed
+  products.
+- Use consistent cards for section navigation and compact tables for comparing
+  entries.
+- Keep tables usable at mobile widths.
+- Avoid screenshots unless they materially improve recognition and can be
+  maintained.
+- Use descriptive link text rather than “I want convenience” or “I’m an
+  expert.”
+- Do not end every page with a generic link back to Resources when normal
+  navigation already provides that route.
+
+## Verification plan
+
+### Content checks
+
+- Refresh all source evidence immediately before editing.
+- Confirm every name, purpose, maintainer, package, release, and network.
+- Compare `origin/master`, `origin/dev`, the published site, and the official
+  source.
+- Confirm there are no references to `Harbinger` or `Sovrano`.
+- Confirm all five KCS titles and statuses against the canonical repository.
+- Confirm every third-party entry is labeled correctly.
+- Confirm no page contains an unsupported security or financial claim.
+- Confirm Resources does not duplicate Architecture’s resource model.
+
+### Link checks
+
+- Check every internal link and anchor.
+- Check every source and repository link.
+- Check every external resource with bounded timeouts.
+- Follow redirects and verify the final owner and destination.
+- Manually check links that block automated clients.
+- Confirm current-testnet links point to current official sources.
+- Do not leave permanent GitHub links pointing to a feature branch.
+
+Live third-party links can make CI flaky. Prefer:
+
+- deterministic validation for internal paths, required metadata, and banned
+  legacy hosts;
+- a documented manual external-link audit for third-party services;
+- bounded retries only if external link checks are automated.
+
+### Repository checks
+
+Run all checks relevant to the final diff, including:
+
+```bash
+npm run docs:links
+docs-venv/bin/mkdocs build
+git diff --check
+```
+
+If executable examples or their shared infrastructure change, also run:
+
+```bash
+npm run examples:syntax
+npm run examples:verify
+```
+
+Run any additional existing repository validation required by the latest
+`origin/dev`.
+
+### Render review
+
+Review every changed public route locally at desktop and mobile widths.
+
+Check:
+
+- navigation and page order;
+- cards and tables;
+- horizontal code or table overflow;
+- long URLs and link wrapping;
+- heading hierarchy;
+- broken images;
+- internal and external navigation;
+- browser console warnings and errors.
+
+Verify that `drafts/resources/` is not included in the generated MkDocs site.
+Repeat the relevant review on the pull-request deploy preview.
+
+## Implementation phases
+
+### Phase 1: Refresh and classify the inventory
+
+1. Fetch the latest `origin/dev`.
+2. Compare current `master`, `dev`, and published Resources.
+3. Create `RESOURCE_INVENTORY.md`.
+4. Verify official sources and third-party candidates.
+5. Record include, exclude, and pending decisions.
+6. Resolve ambiguous wallet, explorer, package, and network claims before
+   publishing them.
+
+### Phase 2: Rebuild structure and landing page
+
+1. Update the Resources navigation with explicit labels and audience groups.
+2. Rewrite the landing page as a non-duplicative hub.
+3. Restore visible navigation.
+4. Add the directory and non-endorsement explanations.
+5. Add the necessary cross-links to owning chapters.
+
+### Phase 3: Correct user-facing resource pages
+
+1. Complete Wallets.
+2. Correct Explorers and remove Harbinger.
+3. Reorganize ecosystem applications using verified live categories.
+4. Add appropriate security and third-party notices.
+
+### Phase 4: Correct developer-facing resource pages
+
+1. Replace invented KCS descriptions with canonical titles and statuses.
+2. Rebuild the SDK and tooling inventory.
+3. Remove unverified language SDKs, packages, and installation commands.
+4. Add versioned sources and current-project links.
+5. Apply the executable-example policy if any examples are introduced.
+
+### Phase 5: Add community material and discoverability
+
+1. Add Community and learning.
+2. Correct the home-page route to Resources.
+3. Verify official versus community labels.
+4. Check that every Resources page is reachable from both navigation and the
+   landing page.
+
+### Phase 6: Validate and deliver
+
+1. Run content, source, and link audits.
+2. Run repository validation and MkDocs builds.
+3. Review every affected page at desktop and mobile widths.
+4. Review the deploy preview.
+5. Commit only intended Resources and narrow navigation files.
+6. Push `codex/update-resources-docs`.
+7. Open a draft pull request targeting `dev`.
+8. Record sources, exclusions, validation evidence, and remaining third-party
+   limitations in the pull-request description.
+9. Leave the pull request open as a draft.
+
+## Acceptance criteria
+
+The Resources update is complete only when:
+
+1. `docs/resources/wallets.md` is no longer empty.
+2. The landing page is an orientation hub and does not duplicate its child
+   pages.
+3. Resources is clearly discoverable from site navigation and the home page.
+4. The distinction between the Resources directory and the architectural
+   resource-accounting model is explicit.
+5. Harbinger is not presented as the current testnet.
+6. No reference to Sovrano exists in the updated Resources scope.
+7. All KCS titles, purposes, statuses, and links match the canonical repository.
+8. No unverified Python, Go, Rust, or other high-level SDK is presented as
+   supported.
+9. Every listed project has a canonical source, known maintainer, and accurate
+   classification.
+10. Official, community, and third-party resources are visibly distinguished.
+11. No third-party listing is presented as an endorsement, audit, or security
+    guarantee.
+12. No generic or nonexistent DeFi category is presented as a live Koinos
+    application.
+13. Current-testnet references are verified against `koinos/koinos-testnet`.
+14. Source and package links use appropriate immutable versions where technical
+    claims depend on a version.
+15. Any JavaScript example follows the complete-source and executable-link
+    policy.
+16. Internal, source, package, runner, and external links have been checked.
+17. MkDocs and all relevant repository validation pass apart from explicitly
+    recorded pre-existing issues outside this work.
+18. Every changed public page passes desktop and mobile visual review.
+19. Internal inventory and plan files remain outside the generated site.
+20. Only intended files are committed.
+21. A draft pull request is open from `codex/update-resources-docs` to `dev`.
+22. The pull request is not merged or marked ready for review.
+
+## Expected deliverables
+
+- `drafts/resources/RESOURCE_INVENTORY.md`
+- rewritten `docs/resources/index.md`
+- completed `docs/resources/wallets.md`
+- corrected `docs/resources/explorers.md`
+- corrected `docs/resources/ecosystem-platforms.md`
+- corrected `docs/resources/contract-standards.md`
+- rewritten `docs/resources/software-libraries.md`
+- new `docs/resources/community-and-learning.md`
+- updated Resources navigation in `mkdocs.yml`
+- only the narrow home-page or cross-chapter link changes required for
+  discoverability
+- validation evidence in the draft pull request

--- a/drafts/resources/RESOURCE_INVENTORY.md
+++ b/drafts/resources/RESOURCE_INVENTORY.md
@@ -36,7 +36,7 @@
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Koinosblocks | Block explorer | Engrave | Community-maintained | [koinosblocks.com](https://koinosblocks.com/) | [GitLab](https://gitlab.com/engrave/koinos/koinosblocks) | Live head height compared with an official mainnet API on 2026-07-25 | Mainnet verified | Include | No current-public-testnet compatibility or maintained public API documentation verified |
 | Koiner | Explorer/analytics candidate | Not verified | Third-party | `https://koiner.app/` | Not verified | DNS resolution failed on 2026-07-25 | Not verified | Exclude | Site unreachable; features and ownership could not be verified |
-| KoinosScan | Block explorer candidate | KoinosScan project | Third-party | [koinosscan.com](https://koinosscan.com/) | Not verified | Displayed head was materially behind the official mainnet head on 2026-07-25 | Mainnet, but stale at verification | Exclude | Not sufficiently synchronized for a current directory entry |
+| KoinosScan | Block explorer and analytics platform | interfecto | Community-maintained; source repository hosted by `koinos` | [koinosscan.com](https://koinosscan.com/) | [koinos/koinos-token-tracker](https://github.com/koinos/koinos-token-tracker) | Commit [`c625f58`](https://github.com/koinos/koinos-token-tracker/commit/c625f58aba806eb821036cd27fcea26ebbedfd7d); live indexer status was 55 blocks behind the official mainnet head, consistent with documented last-irreversible-block indexing | Mainnet verified | Include | No current-public-testnet compatibility verified; market data and historical-claim classifications can depend on external data or project-defined heuristics |
 | Koinscan | Block explorer and network dashboard | Armana | Third-party | [koinscan.com](https://www.koinscan.com/) | Not verified | Live site build `v0.1.0` (`e1b4fbe`); displayed head was within three blocks of the official mainnet API during review | Mainnet verified | Include | Site identifies itself as early beta; no current-public-testnet compatibility, public source repository, or public API documentation verified |
 | Koinos public testnet repository | Network status and configuration | Koinos Group | Official | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | Commit [`0c37959`](https://github.com/koinos/koinos-testnet/commit/0c37959074d1d66bfafb90f44d5a6c5c5c1c5a50) and release [`v0.1.0-public-testnet`](https://github.com/koinos/koinos-testnet/releases/tag/v0.1.0-public-testnet) | Current public testnet | Include as network source | Not a graphical explorer |
 
@@ -104,9 +104,9 @@ The reviewed immutable revision is commit
 - Public wallet entries: Kondor, Tangem, and the community-maintained `kcli`
   command-line wallet with explicit source/dependency limitations. Koinos CLI
   is a developer-tool cross-reference.
-- Public explorer entries: Koinosblocks and Koinscan for mainnet. The official
-  current-public-testnet repository is linked as the network authority because
-  no current public-testnet explorer was verified.
+- Public explorer entries: Koinosblocks, KoinosScan, and Koinscan for mainnet.
+  The official current-public-testnet repository is linked as the network
+  authority because no current public-testnet explorer was verified.
 - Public ecosystem entries: KoinDX, Vortex Bridge, Koin Krew, Fogata, BurnKoin,
   Koinos One, and Teleno.
 - Public developer entries: Koilib, the AssemblyScript SDK and CLI, the C++ SDK,

--- a/drafts/resources/RESOURCE_INVENTORY.md
+++ b/drafts/resources/RESOURCE_INVENTORY.md
@@ -36,7 +36,7 @@
 | Koinosblocks | Block explorer | Engrave | Community-maintained | [koinosblocks.com](https://koinosblocks.com/) | [GitLab](https://gitlab.com/engrave/koinos/koinosblocks) | Live head height compared with an official mainnet API on 2026-07-25 | Mainnet verified | Include | No current-public-testnet compatibility or maintained public API documentation verified |
 | Koiner | Explorer/analytics candidate | Not verified | Third-party | `https://koiner.app/` | Not verified | DNS resolution failed on 2026-07-25 | Not verified | Exclude | Site unreachable; features and ownership could not be verified |
 | KoinosScan | Block explorer candidate | KoinosScan project | Third-party | [koinosscan.com](https://koinosscan.com/) | Not verified | Displayed head was materially behind the official mainnet head on 2026-07-25 | Mainnet, but stale at verification | Exclude | Not sufficiently synchronized for a current directory entry |
-| Koinscan | Explorer/analytics candidate | Not independently verified | Third-party | `https://koinscan.io/` | Not verified | DNS resolution failed during the browser review on 2026-07-25 | Not verified | Exclude | Site and current ownership could not be verified |
+| Koinscan | Block explorer and network dashboard | Armana | Third-party | [koinscan.com](https://www.koinscan.com/) | Not verified | Live site build `v0.1.0` (`e1b4fbe`); displayed head was within three blocks of the official mainnet API during review | Mainnet verified | Include | Site identifies itself as early beta; no current-public-testnet compatibility, public source repository, or public API documentation verified |
 | Koinos public testnet repository | Network status and configuration | Koinos Group | Official | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | Commit [`0c37959`](https://github.com/koinos/koinos-testnet/commit/0c37959074d1d66bfafb90f44d5a6c5c5c1c5a50) and release [`v0.1.0-public-testnet`](https://github.com/koinos/koinos-testnet/releases/tag/v0.1.0-public-testnet) | Current public testnet | Include as network source | Not a graphical explorer |
 
 ## Ecosystem application and service candidates
@@ -44,11 +44,14 @@
 | Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | KoinDX | Decentralized exchange application | KoinDX | Third-party | [koindx.com](https://koindx.com/) | [KoinDX GitHub](https://github.com/koindx) | Live application and project links checked 2026-07-25 | Mainnet verified through the live application | Include | No claims about liquidity, pricing, returns, or contract security |
-| Kollection | NFT marketplace candidate | Kollection | Third-party | `https://kollection.app/` | Not verified | Initial browser review rendered the application, but both the final bounded URL audit and a fresh browser check failed DNS resolution | Not verified at final review | Exclude | The canonical site was not consistently reachable at delivery time |
+| Kollection | NFT marketplace source candidate | Kollection | Third-party | [GitHub organization](https://github.com/kollection-nft) | [Marketplace repository](https://github.com/kollection-nft/marketplace) | GitHub organization and source remain available; `kollection.app` failed DNS during final review | No live network compatibility verified | Exclude from live application directory | Source is available, but no consistently reachable current application was verified |
 | Koinos Account Protocol (KAP) | Account naming candidate | Top Level Accounts | Third-party | `https://kap.domains/` | Not verified | Domain redirected to an expired-domain service during the final URL audit | Not verified | Exclude | No current canonical application destination remained available |
 | Vortex Bridge | Cross-chain bridge | Vortex | Third-party | [vortexbridge.io](https://vortexbridge.io/) | Not verified | Live bridge interface checked 2026-07-25 | Networks shown by the live application; users must recheck before use | Include | Bridge use has third-party and cross-chain risks; no security assessment performed |
 | Fogata | Block-production pool interface | Fogata / Julián González | Third-party | [fogata.io](https://fogata.io/) | [joticajulian/fogata](https://github.com/joticajulian/fogata) | Live pool interface checked 2026-07-25 | Mainnet entry only | Include | No reward, availability, or performance claims |
 | BurnKoin | Block-production pool interface | Luke Willis / BurnKoin project | Third-party | [burnkoin.com](https://burnkoin.com/) | [Pool contracts](https://github.com/lukemwillis/koinos-burn-pool) and [web interface](https://github.com/lukemwillis/koinos-burn-pool-ui) | Live pool interface and project links checked 2026-07-25 | Mainnet entry only | Include | Linked repositories are older than the live site; no reward, availability, or performance claims |
+| Koin Krew | Community application portal | Koin Krew project | Third-party | [koincrew.com](https://koincrew.com/) | Not verified | Live site and [application portal](https://app.koincrew.com/) checked 2026-07-25 | Koinos mainnet interface verified from current token, contract, and application destinations | Include | Wallet-connected token, NFT, airdrop, and ownership-verification features; no source repository or contract assessment verified |
+| Koinos One | Desktop node-management application | Community contributors led by Pablo García | Community-maintained; repository hosted by `koinos` | [Repository](https://github.com/koinos/koinos-one) | [koinos/koinos-one](https://github.com/koinos/koinos-one) | Release [`v1.1.1`](https://github.com/koinos/koinos-one/releases/tag/v1.1.1); commit [`1e84415`](https://github.com/koinos/koinos-one/commit/1e844159973765615f72bd35c6c546f739322c66) | Koinos mainnet capability documented; selected network must be verified | Include | Community-driven experimental macOS-first application; official reference node remains the microservice implementation |
+| Teleno | Monolithic native Koinos-compatible node | Community contributors led by Pablo García | Community-maintained; repository hosted by `koinos` | [Repository](https://github.com/koinos/teleno) | [koinos/teleno](https://github.com/koinos/teleno) | Release [`teleno-node-v1.1.0`](https://github.com/koinos/teleno/releases/tag/teleno-node-v1.1.0); commit [`787d7cf`](https://github.com/koinos/teleno/commit/787d7cf37e5d2134ebc72faf944381a6aa4462a3) | Koinos mainnet compatibility documented; selected network must be verified | Include | Experimental single-binary alternative; official reference node remains the microservice implementation |
 | KoinCity | Application/platform candidate | Not verified | Third-party | `https://koincity.com/` | Not verified | DNS resolution failed during browser review on 2026-07-25 | Not verified | Exclude | Current application and purpose could not be verified |
 | Krypto Bulls | Game candidate | Krypto Bulls | Third-party | [kryptobulls.io](https://kryptobulls.io/) | Not verified | Site displayed “Coming Soon” on 2026-07-25 | Not verified | Exclude | No live application verified |
 | Koinos Garden | Investment/community candidate | Koinos Garden | Third-party | [koinosgarden.com](https://koinosgarden.com/) | Not verified | Discovery source reviewed 2026-07-25 | Not applicable | Exclude | Outside the narrow application-directory scope and would require financial context |
@@ -99,12 +102,18 @@ The reviewed immutable revision is commit
 
 - Public wallet entries: Kondor and Tangem. Koinos CLI is a developer-tool
   cross-reference.
-- Public explorer entry: Koinosblocks for mainnet. The official current-public-
-  testnet repository is linked as the network authority because no current
-  public-testnet explorer was verified.
-- Public ecosystem entries: KoinDX, Vortex Bridge, Fogata, and BurnKoin.
+- Public explorer entries: Koinosblocks and Koinscan for mainnet. The official
+  current-public-testnet repository is linked as the network authority because
+  no current public-testnet explorer was verified.
+- Public ecosystem entries: KoinDX, Vortex Bridge, Koin Krew, Fogata, BurnKoin,
+  Koinos One, and Teleno.
 - Public developer entries: Koilib, the AssemblyScript SDK and CLI, the C++ SDK,
   Koinos CLI, local testnet, Mock VM, and protocol definitions.
 - A resource may be reconsidered after its maintainer supplies a canonical URL,
   ownership information, supported-network evidence, and a reproducible current
   verification path.
+- Website PR
+  [koinos/koinos-io-website#142](https://github.com/koinos/koinos-io-website/pull/142)
+  was used as a discovery source for Koinscan, Koin Krew, Koinos One, Teleno,
+  and the updated Kollection destination. Each candidate was independently
+  checked; the website list was not treated as verification by itself.

--- a/drafts/resources/RESOURCE_INVENTORY.md
+++ b/drafts/resources/RESOURCE_INVENTORY.md
@@ -27,6 +27,7 @@
 | Tangem | Hardware-wallet system | Tangem | Third-party | [KOIN support page](https://tangem.com/en/cryptocurrencies/koinos/) | Not published for the Koinos integration | Current Tangem asset page explicitly lists Koinos support | Koinos | Include | Proprietary product; documentation does not assess firmware, custody design, or security |
 | Konio | Mobile wallet | Not verified | Third-party | `https://konio.io/` | Not verified | Domain redirected to an unrelated parked/insecure destination on 2026-07-25 | Not verified | Exclude | No current canonical source could be established |
 | My Koinos Wallet / Portal | Web wallet | Not verified | Community/third-party | No current canonical URL verified | Not verified | Only older secondary documentation found | Not verified | Exclude | Insufficient current primary evidence |
+| kcli | Command-line wallet and blockchain interaction tool | Pablo García | Community-maintained | [Repository](https://github.com/pgarciagon/kcli) | [pgarciagon/kcli](https://github.com/pgarciagon/kcli) | Source version `1.4.0`; commit [`c263df6`](https://github.com/pgarciagon/kcli/commit/c263df637eb632e275e77f807777aa64c3fd54ed); clean install, TypeScript build, help, changes output, and read-only mainnet/testnet connections verified 2026-07-25 | Mainnet and current public testnet are implemented; testnet constants matched `koinos/koinos-testnet` commit `0c37959` | Include with prominent limitations | No published release or registry package; some commands accept secrets as process arguments or print WIFs; `npm audit --omit=dev` reported 20 production dependency advisories, including one critical; a saved mainnet RPC overrode `--network testnet` during verification, causing a read command to query mainnet under a testnet label |
 | Koinos CLI | Command-line account and transaction tool | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-cli) | [koinos/koinos-cli](https://github.com/koinos/koinos-cli) | [v2.0.0](https://github.com/koinos/koinos-cli/releases/tag/v2.0.0) | Network depends on the selected endpoint | Cross-reference | Developer/power-user tool, not presented as a consumer wallet |
 
 ## Explorers and network-tool candidates
@@ -100,8 +101,9 @@ The reviewed immutable revision is commit
 
 ## Public-page decisions
 
-- Public wallet entries: Kondor and Tangem. Koinos CLI is a developer-tool
-  cross-reference.
+- Public wallet entries: Kondor, Tangem, and the community-maintained `kcli`
+  command-line wallet with explicit source/dependency limitations. Koinos CLI
+  is a developer-tool cross-reference.
 - Public explorer entries: Koinosblocks and Koinscan for mainnet. The official
   current-public-testnet repository is linked as the network authority because
   no current public-testnet explorer was verified.

--- a/drafts/resources/RESOURCE_INVENTORY.md
+++ b/drafts/resources/RESOURCE_INVENTORY.md
@@ -1,0 +1,110 @@
+# Resources inventory
+
+> **Internal documentation record — not published by MkDocs**
+>
+> This inventory records the evidence used for the Resources directory review.
+> Inclusion means that the linked resource and the limited purpose described in
+> the public documentation were verified on the date shown. It is not an audit,
+> endorsement, or guarantee of availability.
+
+## Review rules
+
+- Verify a project through its canonical site, repository, package registry, or
+  an official Koinos source.
+- Use the current public testnet repository as the authority for testnet claims.
+- Do not infer ownership, maintenance, network support, or security from a name.
+- Exclude resources that are unreachable, materially stale, unsupported, or
+  lack enough primary evidence.
+- Recheck all included resources before each Resources update.
+
+**Verification date for every candidate row in this inventory: 2026-07-25.**
+
+## Wallet candidates
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Kondor | Browser wallet | Julián González | Community-maintained | [Website](https://kondorwallet.com/) | [joticajulian/kondor](https://github.com/joticajulian/kondor) | Repository activity and current Chrome Web Store listing checked 2026-07-25 | Koinos; the user must verify the selected network before signing | Include | Browser extension; compatibility and network selection can change |
+| Tangem | Hardware-wallet system | Tangem | Third-party | [KOIN support page](https://tangem.com/en/cryptocurrencies/koinos/) | Not published for the Koinos integration | Current Tangem asset page explicitly lists Koinos support | Koinos | Include | Proprietary product; documentation does not assess firmware, custody design, or security |
+| Konio | Mobile wallet | Not verified | Third-party | `https://konio.io/` | Not verified | Domain redirected to an unrelated parked/insecure destination on 2026-07-25 | Not verified | Exclude | No current canonical source could be established |
+| My Koinos Wallet / Portal | Web wallet | Not verified | Community/third-party | No current canonical URL verified | Not verified | Only older secondary documentation found | Not verified | Exclude | Insufficient current primary evidence |
+| Koinos CLI | Command-line account and transaction tool | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-cli) | [koinos/koinos-cli](https://github.com/koinos/koinos-cli) | [v2.0.0](https://github.com/koinos/koinos-cli/releases/tag/v2.0.0) | Network depends on the selected endpoint | Cross-reference | Developer/power-user tool, not presented as a consumer wallet |
+
+## Explorers and network-tool candidates
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Koinosblocks | Block explorer | Engrave | Community-maintained | [koinosblocks.com](https://koinosblocks.com/) | [GitLab](https://gitlab.com/engrave/koinos/koinosblocks) | Live head height compared with an official mainnet API on 2026-07-25 | Mainnet verified | Include | No current-public-testnet compatibility or maintained public API documentation verified |
+| Koiner | Explorer/analytics candidate | Not verified | Third-party | `https://koiner.app/` | Not verified | DNS resolution failed on 2026-07-25 | Not verified | Exclude | Site unreachable; features and ownership could not be verified |
+| KoinosScan | Block explorer candidate | KoinosScan project | Third-party | [koinosscan.com](https://koinosscan.com/) | Not verified | Displayed head was materially behind the official mainnet head on 2026-07-25 | Mainnet, but stale at verification | Exclude | Not sufficiently synchronized for a current directory entry |
+| Koinscan | Explorer/analytics candidate | Not independently verified | Third-party | `https://koinscan.io/` | Not verified | DNS resolution failed during the browser review on 2026-07-25 | Not verified | Exclude | Site and current ownership could not be verified |
+| Koinos public testnet repository | Network status and configuration | Koinos Group | Official | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | [koinos/koinos-testnet](https://github.com/koinos/koinos-testnet) | Commit [`0c37959`](https://github.com/koinos/koinos-testnet/commit/0c37959074d1d66bfafb90f44d5a6c5c5c1c5a50) and release [`v0.1.0-public-testnet`](https://github.com/koinos/koinos-testnet/releases/tag/v0.1.0-public-testnet) | Current public testnet | Include as network source | Not a graphical explorer |
+
+## Ecosystem application and service candidates
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| KoinDX | Decentralized exchange application | KoinDX | Third-party | [koindx.com](https://koindx.com/) | [KoinDX GitHub](https://github.com/koindx) | Live application and project links checked 2026-07-25 | Mainnet verified through the live application | Include | No claims about liquidity, pricing, returns, or contract security |
+| Kollection | NFT marketplace candidate | Kollection | Third-party | `https://kollection.app/` | Not verified | Initial browser review rendered the application, but both the final bounded URL audit and a fresh browser check failed DNS resolution | Not verified at final review | Exclude | The canonical site was not consistently reachable at delivery time |
+| Koinos Account Protocol (KAP) | Account naming candidate | Top Level Accounts | Third-party | `https://kap.domains/` | Not verified | Domain redirected to an expired-domain service during the final URL audit | Not verified | Exclude | No current canonical application destination remained available |
+| Vortex Bridge | Cross-chain bridge | Vortex | Third-party | [vortexbridge.io](https://vortexbridge.io/) | Not verified | Live bridge interface checked 2026-07-25 | Networks shown by the live application; users must recheck before use | Include | Bridge use has third-party and cross-chain risks; no security assessment performed |
+| Fogata | Block-production pool interface | Fogata / Julián González | Third-party | [fogata.io](https://fogata.io/) | [joticajulian/fogata](https://github.com/joticajulian/fogata) | Live pool interface checked 2026-07-25 | Mainnet entry only | Include | No reward, availability, or performance claims |
+| BurnKoin | Block-production pool interface | Luke Willis / BurnKoin project | Third-party | [burnkoin.com](https://burnkoin.com/) | [Pool contracts](https://github.com/lukemwillis/koinos-burn-pool) and [web interface](https://github.com/lukemwillis/koinos-burn-pool-ui) | Live pool interface and project links checked 2026-07-25 | Mainnet entry only | Include | Linked repositories are older than the live site; no reward, availability, or performance claims |
+| KoinCity | Application/platform candidate | Not verified | Third-party | `https://koincity.com/` | Not verified | DNS resolution failed during browser review on 2026-07-25 | Not verified | Exclude | Current application and purpose could not be verified |
+| Krypto Bulls | Game candidate | Krypto Bulls | Third-party | [kryptobulls.io](https://kryptobulls.io/) | Not verified | Site displayed “Coming Soon” on 2026-07-25 | Not verified | Exclude | No live application verified |
+| Koinos Garden | Investment/community candidate | Koinos Garden | Third-party | [koinosgarden.com](https://koinosgarden.com/) | Not verified | Discovery source reviewed 2026-07-25 | Not applicable | Exclude | Outside the narrow application-directory scope and would require financial context |
+
+## Contract standards
+
+Canonical repository: [koinos/koinos-contract-standards](https://github.com/koinos/koinos-contract-standards).
+The reviewed immutable revision is commit
+[`ef6f3d8`](https://github.com/koinos/koinos-contract-standards/commit/ef6f3d8edc75673842e927edba1232fe47df51e4).
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| KCS-1 | Contract standard | Listed KCS authors and Koinos repository maintainers | Official repository | [Latest](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-1.md) | Canonical repository above | Reviewed at `ef6f3d8`: “Token Standard”, Final | Network-independent interface | Include | Summary does not replace the specification |
+| KCS-2 | Contract standard | Listed KCS authors and Koinos repository maintainers | Official repository | [Latest](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-2.md) | Canonical repository above | Reviewed at `ef6f3d8`: “NFT Collection Standard”, Final | Network-independent interface | Include | Summary does not replace the specification |
+| KCS-3 | Contract standard | Listed KCS authors and Koinos repository maintainers | Official repository | [Latest](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-3.md) | Canonical repository above | Reviewed at `ef6f3d8`: “Token Standard that mimics ERC-20”, Final | Network-independent interface | Include | Summary does not replace the specification |
+| KCS-4 | Contract standard | Listed KCS authors and Koinos repository maintainers | Official repository | [Latest](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-4.md) | Canonical repository above | Reviewed at `ef6f3d8`: title recorded in public page, Pending | Network-independent interface | Include | Pending status may change |
+| KCS-5 | Contract standard | Listed KCS authors and Koinos repository maintainers | Official repository | [Latest](https://github.com/koinos/koinos-contract-standards/blob/master/KCSs/kcs-5.md) | Canonical repository above | Reviewed at `ef6f3d8`: title recorded in public page, Pending | Network-independent interface | Include | Pending status may change |
+
+## SDK, library, and developer-tool candidates
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Koilib | JavaScript/TypeScript blockchain interaction | Julián González | Community-maintained | [npm](https://www.npmjs.com/package/koilib) | [joticajulian/koilib](https://github.com/joticajulian/koilib) | npm `9.2.0`; commit [`ae5b267`](https://github.com/joticajulian/koilib/commit/ae5b2671ee5f31cb9c8f66f3007a4451026d3ec7) | Endpoint-dependent | Include | Application library, not a node implementation |
+| Koinos AssemblyScript SDK | Smart-contract SDK | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-sdk-as) | Same | npm `@koinos/sdk-as` `1.4.0`; commit [`d93ad34`](https://github.com/koinos/koinos-sdk-as/commit/d93ad345a34fa65bfd7a25ec5fc3c7ad9d428f21) | Contract/runtime version-dependent | Include | Verify compatibility for the target chain release |
+| Koinos AssemblyScript SDK CLI | Contract project CLI | Koinos Group | Official | [npm](https://www.npmjs.com/package/@koinos/sdk-as-cli) | [koinos/koinos-sdk-as-cli](https://github.com/koinos/koinos-sdk-as-cli) | npm `1.0.2`; commit [`6c0a7cb`](https://github.com/koinos/koinos-sdk-as-cli/commit/6c0a7cb18533a02e442998de0d4575e263077b34) | Contract/runtime version-dependent | Include | Published package version differs from the repository package manifest |
+| Koinos C++ SDK | Smart-contract SDK | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-sdk-cpp) | Same | Release [`v1.0.0`](https://github.com/koinos/koinos-sdk-cpp/releases/tag/v1.0.0) | Contract/runtime version-dependent | Include | Older release; verify compatibility before starting a new project |
+| Koinos CLI | Command-line interaction | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-cli) | Same | Release [`v2.0.0`](https://github.com/koinos/koinos-cli/releases/tag/v2.0.0) | Endpoint-dependent | Include | Transactions may be state-changing; inspect before signing |
+| Koinos local testnet | Local integration environment | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-local-testnet) | Same | Commit [`2508a39`](https://github.com/koinos/koinos-local-testnet/commit/2508a39826d6632238edd8a1138c1b42c7ca8cbd) | Local development network | Include | Separate from the current public testnet |
+| Koinos Mock VM | Local contract testing | Koinos Group | Official | [npm](https://www.npmjs.com/package/@koinos/mock-vm) | [koinos/koinos-mock-vm](https://github.com/koinos/koinos-mock-vm) | npm `1.2.0`; commit [`b7bcd44`](https://github.com/koinos/koinos-mock-vm/commit/b7bcd4483447c0d70529ff9d4d5fe4dd5d6b25e7) | Local test runtime | Include | A mock does not replace integration testing |
+| Koinos protocol definitions | Protocol schemas and generated bindings | Koinos Group | Official | [Repository](https://github.com/koinos/koinos-proto) | Same | Release [`v2.6.0`](https://github.com/koinos/koinos-proto/releases/tag/v2.6.0) | Protocol version-dependent | Include | Generated bindings are low-level protocol types, not complete SDKs |
+| Arkinos | Development framework candidate | Not verified | Community/third-party | npm listing only | Not verified | No sufficiently current canonical support evidence established | Not verified | Exclude | Maintenance and current compatibility not established |
+| Python, Go, and Rust high-level SDK claims | High-level SDK candidates | Not verified | Not verified | None | None | No current canonical supported implementations established | Not verified | Exclude | Protocol bindings must not be described as complete high-level SDKs |
+
+## Community and learning sources
+
+| Resource | Category | Maintainer | Ownership | Canonical URL | Repository | Version evidence | Supported network | Status | Limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Koinos website | Project information | Koinos Group | Official | [koinos.io](https://koinos.io/) | Not applicable | Live site checked 2026-07-25 | General | Include | Ecosystem listings are discovery leads, not verification by themselves |
+| Koinos documentation | Documentation | Koinos Docs contributors | Official | [docs.koinos.io](https://docs.koinos.io/) | [koinos/koinos-docs](https://github.com/koinos/koinos-docs) | Current published site and repository checked 2026-07-25 | General | Include | Report stale content through the repository issue tracker |
+| Koinos GitHub organization | Source and contribution | Koinos Group | Official | [github.com/koinos](https://github.com/koinos) | Organization repositories | Live organization checked 2026-07-25 | General | Include | Individual repository status must still be checked |
+| Koinos Telegram | Community discussion | Koinos community moderators | Officially linked community channel | [telegram.koinos.io](https://telegram.koinos.io/) | Not applicable | Official redirect and destination checked 2026-07-25 | General | Include | Public chat; verify advice before acting |
+| Koinos Discord | Community/developer discussion | Koinos community moderators | Officially linked community channel | [discord.koinos.io](https://discord.koinos.io/) | Not applicable | Linked from the current official website on 2026-07-25 | General | Include | Invite/redirect behavior can change |
+| Koinos YouTube | Video learning and project updates | Koinos Group | Official | [YouTube channel](https://www.youtube.com/@koinosgroup) | Not applicable | Current channel checked 2026-07-25 | General | Include | Older videos may describe obsolete networks or releases |
+| Koinos Medium | Project articles | Koinos Network | Official project publication | [Medium publication](https://medium.com/koinosnetwork) | Not applicable | Current publication checked 2026-07-25 | General | Include | Older articles may be historical |
+| Koinos on X | Project updates | Koinos Network | Official | [x.com/koinosnetwork](https://x.com/koinosnetwork) | Not applicable | Linked from the current official website on 2026-07-25 | General | Include | Not a substitute for versioned technical documentation |
+
+## Public-page decisions
+
+- Public wallet entries: Kondor and Tangem. Koinos CLI is a developer-tool
+  cross-reference.
+- Public explorer entry: Koinosblocks for mainnet. The official current-public-
+  testnet repository is linked as the network authority because no current
+  public-testnet explorer was verified.
+- Public ecosystem entries: KoinDX, Vortex Bridge, Fogata, and BurnKoin.
+- Public developer entries: Koilib, the AssemblyScript SDK and CLI, the C++ SDK,
+  Koinos CLI, local testnet, Mock VM, and protocol definitions.
+- A resource may be reconsidered after its maintainer supplies a canonical URL,
+  ownership information, supported-network evidence, and a reproducible current
+  verification path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,9 +274,12 @@ nav:
           - references/as-sdk/encoding-functions.md
           - references/as-sdk/koinosbox-functions.md
   - Resources:
-      - resources/index.md
-      - resources/wallets.md
-      - resources/explorers.md
-      - resources/ecosystem-platforms.md
-      - resources/contract-standards.md
-      - resources/software-libraries.md
+      - Resources overview: resources/index.md
+      - For users:
+          - Wallets: resources/wallets.md
+          - Explorers and network tools: resources/explorers.md
+          - Ecosystem applications and services: resources/ecosystem-platforms.md
+      - For developers:
+          - SDKs, libraries, and developer tools: resources/software-libraries.md
+          - Contract standards: resources/contract-standards.md
+      - Community and learning: resources/community-and-learning.md


### PR DESCRIPTION
## Summary

- add the tracked internal Resources plan and a dated candidate inventory outside the published MkDocs tree
- rebuild Resources as a task-oriented directory with visible official, community-maintained, and third-party classifications
- complete wallets, explorers/network tools, ecosystem applications/services, contract standards, and SDK/library/tool pages
- add Community and learning guidance and restore normal nested Resources navigation
- add a narrow Resources card to the home page without rewriting other chapters
- follow up on `koinos/koinos-io-website#142` by independently verifying and documenting Koinscan, Koin Krew, Koinos One, and Teleno
- add `pgarciagon/kcli` as a community-maintained command-line wallet with prominent source, dependency, secret-handling, and network-selection limitations
- add KoinosScan as a community-maintained mainnet explorer and analytics platform, with verified functions, source, API scope, and LIB-based synchronization behavior

## Inventory decisions and verified sources

Public entries are limited to resources with a current canonical source and a purpose that could be verified on 2026-07-25:

- wallets: Kondor, Tangem, and the community-maintained `kcli`; Koinos CLI is a developer-tool cross-reference
- explorer/network sources: Koinosblocks, KoinosScan, and Koinscan for mainnet, plus `koinos/koinos-testnet` as the current public-testnet authority
- ecosystem applications/services: KoinDX, Vortex Bridge, Koin Krew, Fogata, BurnKoin, Koinos One, and Teleno
- developer tools: Koilib, the AssemblyScript SDK and CLI, C++ SDK, Koinos CLI, local testnet, Mock VM, and protocol definitions
- standards: KCS-1 through KCS-5, checked at immutable commit `ef6f3d8edc75673842e927edba1232fe47df51e4`, with current-source links alongside the reviewed links

Package versions were checked against npm and linked to immutable repository commits where applicable. Version-dependent official tools link releases/tags or reviewed commits plus their canonical repositories.

The internal inventory records category, maintainer, ownership, canonical URL, repository evidence, supported network, verification date, decision, and limitations for included and excluded candidates.

### kcli verification

`pgarciagon/kcli` was reviewed at source version `1.4.0`, commit `c263df637eb632e275e77f807777aa64c3fd54ed`:

- a clean `npm ci` and TypeScript build passed
- `--help` and `--changes` matched the documented command surface
- read-only mainnet and current-public-testnet connections were executed; the testnet constants match `koinos/koinos-testnet` commit `0c37959074d1d66bfafb90f44d5a6c5c5c1c5a50`
- no release or package-registry distribution was found; installation is from source
- some commands accept a WIF or seed phrase as a process argument, and wallet generation prints the WIF
- `npm audit --omit=dev` reported 20 production-dependency advisories: 14 low, 4 moderate, 1 high, and 1 critical
- with a saved mainnet RPC, `--network testnet chain-info` queried mainnet while displaying a testnet label; an explicit current testnet RPC worked. The public page therefore requires independent RPC and chain-ID verification and does not rely on the network label.

No state-changing `kcli` command was executed during verification.

### Website ecosystem discovery

Website PR `koinos/koinos-io-website#142` was treated only as a discovery source:

- Koinscan's corrected `.com` site was live, labeled early beta, and displayed a mainnet head within three blocks of the official API during review; no public source repository, testnet support, or documented public API was inferred
- Koin Krew's live site and application portal verified token-tracking, NFT, airdrop, and ownership-verification tools; the directory does not assess its tokens, prices, contracts, or wallet-connected operations
- Koinos One `v1.1.1` and Teleno `teleno-node-v1.1.0` were verified from their current repositories/releases and are explicitly framed as community-led experimental alternatives; the microservice-based Koinos node remains the official reference implementation
- Kollection's GitHub organization/source remains available, but no consistently reachable live application was verified, so it remains excluded from the public live-application directory

### KoinosScan verification

KoinosScan was reviewed as a community-maintained project led by `interfecto`:

- the live site provides address and transaction-hash search; recent block, transaction, and block-producer views; KOIN and VHP balances, holder rankings, transfer history, and distribution charts; and historical KOIN ERC-20 claim analytics
- the open-source `koinos/koinos-token-tracker` indexer was reviewed at commit `c625f58aba806eb821036cd27fcea26ebbedfd7d`
- the public Token Tracker API documentation covers indexed addresses, holders, transfers, blocks, tokens, and indexer status; it is explicitly documented as an indexer API rather than a general-purpose Koinos node API
- the live indexer was 55 blocks behind the official chain head during review, consistent with its documented policy of indexing through the last irreversible block, normally about 60 blocks behind head
- mainnet support was verified; current-public-testnet support was not verified
- market information and claim analytics can depend on external data or project heuristics and are presented with that limitation

## Exclusions and limitations

Excluded or removed entries include:

- wallet sites with parked/unsafe destinations or insufficient current primary evidence
- explorer and platform candidates that failed DNS resolution, redirected to an expired-domain service, lacked evidence of current network coverage, or were not yet live
- Arkinos and supposed Python, Go, or Rust high-level SDKs without current canonical supported implementations
- obsolete Harbinger links and all Sovrano references from the public Resources pages
- API claims where no current maintained API documentation was verified

The public pages make no security, audit, liquidity, reward, return, performance, reliability, or endorsement claims. Third-party bridge, wallet, signing, recovery-material, wallet-connected-application, command-line-secret, dependency, and network-selection cautions are included.

## Cross-chapter changes

The only cross-chapter file changed is `docs/index.md`: the combined References/Resources card is split into a References card and a Resources card. Resources pages link to Getting Started, Interacting, Contracts, Node Operators, Architecture, and References; those chapters were not modified.

## Validation

- `npm run docs:links` — passed; the checker reports its two documented pre-existing exceptions
- `docs-venv/bin/mkdocs build` — passed
- `docs-venv/bin/mkdocs build --strict` — reaches only two warnings already present in `origin/dev`: missing `exchanges/jsonrpc.md` in nav and missing `interacting/koilib.md` from `docs/index.md`
- `git diff --check` — passed
- generated-site audit — passed; no `drafts/resources` content appears under `site/`
- forbidden-name and feature-branch-link audits — passed for public Resources pages
- initial external URL audit — 57 URLs checked with bounded timeouts; 52 returned 2xx. Four npm pages and Medium rejected the automated request with 403 and were verified through npm registry metadata/current page inspection. Redirect destinations were inspected.
- website-PR follow-up URL audit — all nine newly referenced canonical/release URLs returned 200 after redirects
- kcli follow-up URL audit — repository, immutable commit, advisory, and current testnet-repository URLs returned 200
- KoinosScan follow-up URL audit — live site, API documentation, maintainer profile, source repository, and immutable reviewed commit all returned 200
- local browser review — all changed public Resources pages plus the home page reviewed at desktop and mobile widths; no page-level overflow, broken images, or browser console errors were found. Wallet and KCS content was changed from wide tables to responsive stacked content after mobile review.
- ecosystem follow-up local/browser review — the changed Resources hub, explorers, ecosystem page, Koinscan section, and node-software section were checked at 1280×720 and 390×844; no content overflow or browser console errors were found
- kcli local browser review — wallet page, kcli entry, and complete warning checked at 1280×720 and 390×844; no overflow or browser console errors were found
- KoinosScan local browser review — explorer entry, function list, ownership/source/network/API/synchronization details, and limitations checked at 1280×720 and 390×844; no overflow or browser console errors were found
- deploy-preview browser review — repeated for all eight original routes at 1440×1000 and 390×844; no page-level overflow, broken images, overflowing code blocks, or browser console errors were found
- ecosystem follow-up deploy-preview review — explorers, ecosystem, Koinscan, and node-software content rechecked after commit `20b53b8`; no overflow or browser console errors were found
- kcli follow-up deploy-preview review — wallet/kcli content rechecked at 1280×720 and 390×844 after commit `21a73e1`; no overflow or browser console errors were found
- KoinosScan follow-up deploy-preview review — the explorer entry was checked at 1280×720 and 390×844 after commit `4fd37da`; no content overflow or browser console errors were found
- remote checks — GitHub `verify` passed; Netlify deploy preview and redirect checks passed (header/pages checks were skipped by Netlify as not applicable)

No JavaScript documentation example changed, so example syntax/runtime checks were not applicable.

## Review limits

Availability and third-party project status can change after the verification date. The inventory preserves rejected candidates and reasons so a future update can re-evaluate them from fresh canonical evidence.
